### PR TITLE
Specify transactional propagation type in docs

### DIFF
--- a/src/docs/asciidoc/40-events.adoc
+++ b/src/docs/asciidoc/40-events.adoc
@@ -87,7 +87,7 @@ To run a transactional event listener in a transaction itself, it would need to 
 class InventoryManagement {
 
   @Async
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   @TransactionalEventListener
   void on(OrderCompleted event) { /* … */ }
 }


### PR DESCRIPTION
This [issue](https://github.com/spring-projects/spring-modulith/issues/80) already explains why `Propagation.REQUIRES_NEW` needs to be used just reflecting this in the docs example.