### PR TITLE
Update introducing-spring-modulith.adoc

### DIFF
--- a/etc/introducing-spring-modulith.adoc
+++ b/etc/introducing-spring-modulith.adoc
@@ -144,7 +144,7 @@ class OrderIntegrationTests {
 
     // Find all OrderCompleted events referring to our reference order
     var matchingMapped = events.ofType(OrderCompleted.class)
-        .matchingMapped(OrderCompleted::getOrderId, reference.getId()::equals);
+        .matching(OrderCompleted::orderId, reference.getId());
 
     assertThat(matchingMapped).hasSize(1);
   }


### PR DESCRIPTION
Replaced the deprecated matchingMapped with matching, and adapted the way the orderId is read from the event