### PR TITLE
GH-374 - fix for EnablePersistentDomainEvents incompatibility with EventPublicationAutoConfiguration

### DIFF
--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/EventPublicationAutoConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/EventPublicationAutoConfiguration.java
@@ -62,6 +62,7 @@ public class EventPublicationAutoConfiguration extends EventPublicationConfigura
 	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	@ConditionalOnBean(EventPublicationRepository.class)
+	@ConditionalOnMissingBean
 	EventPublicationRegistry eventPublicationRegistry(EventPublicationRepository repository,
 			ObjectProvider<Clock> clock) {
 		return super.eventPublicationRegistry(repository, clock);
@@ -70,6 +71,7 @@ public class EventPublicationAutoConfiguration extends EventPublicationConfigura
 	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	@ConditionalOnBean(EventPublicationRegistry.class)
+	@ConditionalOnMissingBean
 	static PersistentApplicationEventMulticaster applicationEventMulticaster(
 			ObjectFactory<EventPublicationRegistry> eventPublicationRegistry, ObjectFactory<Environment> environment) {
 
@@ -79,6 +81,7 @@ public class EventPublicationAutoConfiguration extends EventPublicationConfigura
 	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	@ConditionalOnBean(EventPublicationRegistry.class)
+	@ConditionalOnMissingBean
 	static CompletionRegisteringAdvisor completionRegisteringAdvisor(ObjectFactory<EventPublicationRegistry> registry) {
 		return EventPublicationConfiguration.completionRegisteringAdvisor(registry);
 	}

--- a/spring-modulith-events/spring-modulith-events-core/src/test/java/org/springframework/modulith/events/config/EventPublicationAutoConfigurationIntegrationTests.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/test/java/org/springframework/modulith/events/config/EventPublicationAutoConfigurationIntegrationTests.java
@@ -137,6 +137,15 @@ class EventPublicationAutoConfigurationIntegrationTests {
 		});
 	}
 
+	@Test // GH-374
+	void compatibleWithEnablePersistentDomainEvents() {
+		basicSetup()
+				.withUserConfiguration(EnablePersistentDomainEventConfiguration.class)
+				.run(context -> {
+					assertThat(context).hasNotFailed();
+				});
+	}
+
 	private static <T> ContextConsumer<AssertableApplicationContext> expect(Function<Shutdown, T> extractor,
 			@Nullable T expected) {
 
@@ -155,4 +164,7 @@ class EventPublicationAutoConfigurationIntegrationTests {
 
 	@EnableAsync(mode = AdviceMode.ASPECTJ)
 	static class CustomAsyncConfiguration {}
+
+	@EnablePersistentDomainEvents
+	static class EnablePersistentDomainEventConfiguration {}
 }


### PR DESCRIPTION
Fixes [374](https://github.com/spring-projects/spring-modulith/issues/374) and parts of [311](https://github.com/spring-projects/spring-modulith/issues/311)  