### PR TITLE
Potentially broken debug log output in `PersistentApplicationEventMulticaster`

### DIFF
--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
@@ -195,7 +195,7 @@ public class PersistentApplicationEventMulticaster extends AbstractApplicationEv
 	private void doResubmitUncompletedPublicationsOlderThan(@Nullable Duration duration,
 			Predicate<EventPublication> filter) {
 
-		var message = duration != null ? "" : " older than %s".formatted(duration);
+		var message = duration != null ? " older than %s".formatted(duration): "";;
 		var registry = this.registry.get();
 
 		LOGGER.debug("Looking up incomplete event publications {}… ", message);


### PR DESCRIPTION
The main adjustment in this modification primarily involves the ternary operator's condition for the 'message' variable. The original code assigned an empty string to 'message' when 'duration' was not null, otherwise, 'message' was assigned as " older than %s", where %s would be replaced by the value of 'duration'. The updated code now assigns " older than %s" to 'message' when 'duration' is not null; otherwise, 'message' is assigned an empty string.

The purpose of this change might be to provide a more descriptive message when 'duration' is not null instead of an empty string. Therefore, when 'duration' has a value, we can clearly see that 'message' is " older than " appended with the value of 'duration', which provides more information than an empty string.