### PR TITLE
fix(bom): missing events-aws-* modules in BOM

### DIFF
--- a/spring-modulith-bom/pom.xml
+++ b/spring-modulith-bom/pom.xml
@@ -86,6 +86,16 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.modulith</groupId>
+				<artifactId>spring-modulith-events-aws-sns</artifactId>
+				<version>1.2.0-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.modulith</groupId>
+				<artifactId>spring-modulith-events-aws-sqs</artifactId>
+				<version>1.2.0-SNAPSHOT</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.modulith</groupId>
 				<artifactId>spring-modulith-events-tests</artifactId>
 				<version>1.2.0-SNAPSHOT</version>
 			</dependency>


### PR DESCRIPTION
Adds spring-modulith-events-aws-sns and spring-modulith-events-aws-sqs modules to the project BOM.

This fixes https://github.com/spring-projects/spring-modulith/issues/469.