### PR TITLE
Move off deprecated `ApplicationModuleListener` in examples

### DIFF
--- a/spring-modulith-examples/spring-modulith-example-full/src/test/java/example/order/EventPublicationRegistryTests.java
+++ b/spring-modulith-examples/spring-modulith-example-full/src/test/java/example/order/EventPublicationRegistryTests.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.Import;
-import org.springframework.modulith.ApplicationModuleListener;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.modulith.events.core.EventPublicationRegistry;
 import org.springframework.modulith.test.ApplicationModuleTest;
 import org.springframework.modulith.test.Scenario;
@@ -51,7 +51,7 @@ class EventPublicationRegistryTests {
 		var order = new Order();
 
 		scenario.stimulate(() -> orders.complete(order))
-				.andWaitForStateChange(() -> listener.getEx())
+				.andWaitForStateChange(listener::getEx)
 				.andVerify(__ -> {
 					assertThat(registry.findIncompletePublications()).hasSize(1);
 				});


### PR DESCRIPTION
In the spring-modulith-example-full a test used the old deprecated ApplicationModuleListener. I replaced the import with the new one.