### PR TITLE
Use `Types.JavaXTypes.AT_ENTITY` to decide if it is an entity instead of literal `"javax.persistence.Entity"`

### DIFF
--- a/spring-modulith-core/src/main/java/org/springframework/modulith/core/DependencyType.java
+++ b/spring-modulith-core/src/main/java/org/springframework/modulith/core/DependencyType.java
@@ -121,7 +121,7 @@ public enum DependencyType {
 	}
 
 	static DependencyType forParameter(JavaClass type) {
-		return type.isAnnotatedWith("javax.persistence.Entity") ? ENTITY : DEFAULT;
+		return type.isAnnotatedWith(Types.JavaXTypes.AT_ENTITY) ? ENTITY : DEFAULT;
 	}
 
 	static DependencyType forCodeUnit(JavaCodeUnit codeUnit) {


### PR DESCRIPTION
Use Types.JavaXTypes.AT_ENTITY to decide if it is an entity instead of "javax.persistence.Entity"