### PR TITLE
GH-491 - CompletedEventPublications: Delete only completed events

### DIFF
--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/core/DefaultEventPublicationRegistry.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/core/DefaultEventPublicationRegistry.java
@@ -86,6 +86,15 @@ public class DefaultEventPublicationRegistry
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.modulith.events.EventPublicationRegistry#findCompletePublications()
+	 */
+	@Override
+	public Collection<TargetEventPublication> findCompletePublications() {
+		return events.findCompletedPublications();
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.modulith.events.core.EventPublicationRegistry#findIncompletePublicationsOlderThan(java.time.Duration)
 	 */
 	@Override
@@ -123,7 +132,7 @@ public class DefaultEventPublicationRegistry
 		Assert.notNull(duration, "Duration must not be null!");
 
 		events.deleteCompletedPublicationsBefore(clock.instant().minus(duration));
-	};
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -141,7 +150,7 @@ public class DefaultEventPublicationRegistry
 	@Override
 	public void deletePublications(Predicate<EventPublication> filter) {
 
-		var identifiers = findIncompletePublications().stream()
+		var identifiers = findCompletePublications().stream()
 				.filter(filter)
 				.map(TargetEventPublication::getIdentifier)
 				.toList();

--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/core/EventPublicationRegistry.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/core/EventPublicationRegistry.java
@@ -47,6 +47,13 @@ public interface EventPublicationRegistry {
 	Collection<TargetEventPublication> findIncompletePublications();
 
 	/**
+	 * Returns all {@link TargetEventPublication}s that have been completed.
+	 *
+	 * @return will never be {@literal null}.
+	 */
+	Collection<TargetEventPublication> findCompletePublications();
+
+	/**
 	 * Returns all {@link TargetEventPublication}s that have not been completed yet and have been published before the
 	 * given duration in relation to "now".
 	 *


### PR DESCRIPTION
Closes #491. Unlike written in the JavaDoc and official [spring-modulith documentation](https://docs.spring.io/spring-modulith/docs/current-SNAPSHOT/reference/html/#events.publication-registry.managing-publications) the `CompletedEventPublications` deleted only incompleted events.