### PR TITLE
Algolia index name springmodulith -> springdocs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -7,6 +7,7 @@ antora:
   - '@antora/atlas-extension'
   - require: '@springio/antora-extensions/root-component-extension'
     root_component_name: 'modulith'
+  - '@springio/antora-extensions/static-page-extension'
 site:
   title: Spring Modulith
   url: https://docs.spring.io/spring-modulith/reference

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 					<environment>
 						<ALGOLIA_API_KEY>9d489079e5ec46dbb238909fee5c9c29</ALGOLIA_API_KEY>
 						<ALGOLIA_APP_ID>WB1FQYI187</ALGOLIA_APP_ID>
-						<ALGOLIA_INDEX_NAME>springmodulith</ALGOLIA_INDEX_NAME>
+						<ALGOLIA_INDEX_NAME>springdocs</ALGOLIA_INDEX_NAME>
 					</environment>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
antora-ui-spring >= 0.4.0 requires switching to a new index name to support more advanced searches (current version, all projects, etc)