### PR TITLE
Use error log in PersistentApplicationEventMulticaster if listener not found

### DIFF
--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
@@ -187,7 +187,7 @@ public class PersistentApplicationEventMulticaster extends AbstractApplicationEv
 				.map(it -> executeListenerWithCompletion(publication, it)) //
 				.orElseGet(() -> {
 
-					LOGGER.debug("Listener {} not found!", publication.getTargetIdentifier());
+					LOGGER.error("Listener {} not found! Skipping invocation and leaving event publication {} incomplete.", publication.getTargetIdentifier(), publication.getIdentifier());
 					return null;
 				});
 	}


### PR DESCRIPTION
In my opinion, Modulith should not fail silently but should produce an error log.

 resolves #549