### PR TITLE
Add section on how to exclude packages from application module detection

### DIFF
--- a/src/docs/antora/modules/ROOT/pages/verification.adoc
+++ b/src/docs/antora/modules/ROOT/pages/verification.adoc
@@ -29,3 +29,33 @@ If those are configured, dependencies to other application modules are rejected.
 See xref:fundamentals.adoc#modules.explicit-dependencies[Explicit Application Module Dependencies] and xref:fundamentals.adoc#modules.named-interfaces[Named Interfaces] for details.
 
 Spring Modulith optionally integrates with the jMolecules ArchUnit library and, if present, automatically triggers its Domain-Driven Design verification rules described https://github.com/xmolecules/jmolecules-integrations/tree/main/jmolecules-archunit[here].
+
+
+[[excluding-packages]]
+== Excluding Packages
+
+In case you like to exclude certain Java classes or full packages, you can do so with:
+
+[tabs]
+======
+Java::
++
+[source, java, role="primary"]
+----
+ApplicationModules.of(Application.class, JavaClass.Predicates.resideInAPackage("com.example.db")).verify();
+----
+Kotlin::
++
+[source, kotlin, role="secondary"]
+----
+ApplicationModules.of(Application::class, JavaClass.Predicates.resideInAPackage("com.example.db")).verify()
+----
+======
+
+Different examples of exclusions:
+
+* `com.example.db` -- Matches all files in the given package `com.example.db`.
+* `com.example.db..` -- Matches all files in the given package (`com.example.db`) and all sub-packages (`com.example.db.a` or `com.example.db.b.c`).
+* `..example..` -- Matches 'a.example', 'a.example.b' or 'a.b.example.c.d', but not 'a.exam.b'
+
+Full details about possible matchers can be found in the JavaDoc of PackageMatcher: https://github.com/TNG/ArchUnit/blob/main/archunit/src/main/java/com/tngtech/archunit/core/domain/PackageMatcher.java


### PR DESCRIPTION
Within https://github.com/spring-projects/spring-modulith/discussions/416 was a discussion on how to exclude certain packages from verification.

This extension of the documentation hopefully helps people to answer that question.