### PR TITLE
Polishing Asciidoctor

### DIFF
--- a/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Asciidoctor.java
+++ b/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Asciidoctor.java
@@ -192,7 +192,7 @@ class Asciidoctor {
 		return builder.toString();
 	}
 
-	public String renderConfigurationProperties(ApplicationModule module, List<ModuleProperty> properties) {
+	public String renderConfigurationProperties(List<ModuleProperty> properties) {
 
 		if (properties.isEmpty()) {
 			return "none";

--- a/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Asciidoctor.java
+++ b/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Asciidoctor.java
@@ -208,16 +208,14 @@ class Asciidoctor {
 
 					var defaultValue = it.defaultValue();
 
-					if (defaultValue != null && StringUtils.hasText(defaultValue)) {
-
+					if (StringUtils.hasText(defaultValue)) {
 						builder = builder.append(", default ")
-								.append(toInlineCode(defaultValue))
-								.append("");
+								.append(toInlineCode(defaultValue));
 					}
 
 					var description = it.description();
 
-					if (description != null && StringUtils.hasText(description)) {
+					if (StringUtils.hasText(description)) {
 						builder = builder.append(". ")
 								.append(toAsciidoctor(description));
 					}

--- a/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Documenter.java
+++ b/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Documenter.java
@@ -347,7 +347,7 @@ public class Documenter {
 
 				// Properties
 				.append(addTableRow("Properties",
-						asciidoctor.renderConfigurationProperties(module, properties.getModuleProperties(module)), options)) //
+						asciidoctor.renderConfigurationProperties(properties.getModuleProperties(module)), options)) //
 				.append(startOrEndTable())
 				.toString();
 	}


### PR DESCRIPTION
`StringUtils.hasText` already includes non null check so the additional check is not needed. 
Parsing the module in `renderConfigurationProperties` isn't needed anymore because the `ModuleProperty` list is already module specific.