### PR TITLE
GH-581 | add IncompleteEventPublications.findAll method

### DIFF
--- a/spring-modulith-events/spring-modulith-events-api/src/main/java/org/springframework/modulith/events/IncompleteEventPublications.java
+++ b/spring-modulith-events/spring-modulith-events-api/src/main/java/org/springframework/modulith/events/IncompleteEventPublications.java
@@ -16,6 +16,7 @@
 package org.springframework.modulith.events;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.function.Predicate;
 
 /**
@@ -25,6 +26,13 @@ import java.util.function.Predicate;
  * @since 1.1
  */
 public interface IncompleteEventPublications {
+
+	/**
+	 * Returns all {@link EventPublication}s that have not been completed.
+	 *
+	 * @return will never be {@literal null}.
+	 */
+	Collection<? extends EventPublication> findAll();
 
 	/**
 	 * Triggers the re-submission of events for which incomplete {@link EventPublication}s are registered. Note, that this

--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
@@ -144,6 +144,11 @@ public class PersistentApplicationEventMulticaster extends AbstractApplicationEv
 				.toList();
 	}
 
+	@Override
+	public Collection<? extends EventPublication> findAll() {
+		return registry.get().findIncompletePublications();
+	}
+
 	/*
 	* (non-Javadoc)
 	* @see org.springframework.modulith.events.IncompleteEventPublications#resubmitIncompletePublications(java.util.function.Predicate)


### PR DESCRIPTION
Adding possibility to use `IncompleteEventPublications.findAll()` method to return all not completed event publications, in analogy to `CompletedEventPublications.findAll()` method. 