### PR TITLE
GH-644: documenter clean

### DIFF
--- a/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Documenter.java
+++ b/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Documenter.java
@@ -182,18 +182,18 @@ public class Documenter {
 	 * <li>The Module Canvas for each module.</li>
 	 * </ul>
 	 *
-	 * @param options must not be {@literal null}.
+	 * @param diagramOptions must not be {@literal null}.
 	 * @param canvasOptions must not be {@literal null}.
 	 * @return the current instance, will never be {@literal null}.
 	 */
-	public Documenter writeDocumentation(DiagramOptions options, CanvasOptions canvasOptions) {
+	public Documenter writeDocumentation(DiagramOptions diagramOptions, CanvasOptions canvasOptions) {
 
 		if (this.options.clean) {
 			clearOutputFolder();
 		}
 
-		return writeModulesAsPlantUml(options)
-				.writeIndividualModulesAsPlantUml(options) //
+		return writeModulesAsPlantUml(diagramOptions)
+				.writeIndividualModulesAsPlantUml(diagramOptions) //
 				.writeModuleCanvases(canvasOptions);
 	}
 

--- a/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Documenter.java
+++ b/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Documenter.java
@@ -189,7 +189,7 @@ public class Documenter {
 	public Documenter writeDocumentation(DiagramOptions options, CanvasOptions canvasOptions) {
 
 		if (this.options.clean) {
-			clear();
+			clearOutputFolder();
 		}
 
 		return writeModulesAsPlantUml(options)
@@ -531,10 +531,10 @@ public class Documenter {
 				.createComponentView(container, prefix + options.toString(), "");
 	}
 
-	private void clear() {
+	private void clearOutputFolder() {
 
-		try {
-			Files.deleteIfExists(Paths.get(options.outputFolder));
+		try(Stream<Path> paths = Files.walk(Paths.get(options.outputFolder)).sorted(Comparator.reverseOrder())) {
+			paths.map(Path::toFile).forEach(File::delete);
 		} catch (IOException o_O) {
 			throw new RuntimeException(o_O);
 		}


### PR DESCRIPTION
`writeDocumentation` cleans the output directory before writing any documentation files per default.

I think for the other public `writeXYZ` method, clearing the directory does not make any sense since `writeModulesAsPlantUml`, `writeIndividualModulesAsPlantUml` and `writeModuleCanvases` are called from `writeDocumentation` - additional cleans in those methods would delete previously created files.  

@odrotbohm your feedback would be appreciated! :)  
Thanks!

