### PR TITLE
Fix typo in `ApplicationModuleDetectionStrategy.explicitlyAnnotated()`

### DIFF
--- a/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModuleDetectionStrategy.java
+++ b/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModuleDetectionStrategy.java
@@ -53,7 +53,7 @@ public interface ApplicationModuleDetectionStrategy {
 	 *
 	 * @return will never be {@literal null}.
 	 */
-	static ApplicationModuleDetectionStrategy explictlyAnnotated() {
+	static ApplicationModuleDetectionStrategy explicitlyAnnotated() {
 		return pkg -> Stream.of(ApplicationModule.class, JMoleculesTypes.getModuleAnnotationTypeIfPresent())
 				.filter(Objects::nonNull)
 				.flatMap(pkg::getSubPackagesAnnotatedWith);

--- a/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModuleDetectionStrategyLookup.java
+++ b/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModuleDetectionStrategyLookup.java
@@ -97,7 +97,7 @@ class ApplicationModuleDetectionStrategyLookup {
 			case "direct-sub-packages":
 				return ApplicationModuleDetectionStrategy.directSubPackage();
 			case "explicitly-annotated":
-				return ApplicationModuleDetectionStrategy.explictlyAnnotated();
+				return ApplicationModuleDetectionStrategy.explicitlyAnnotated();
 		}
 
 		try {

--- a/spring-modulith-core/src/test/java/org/springframework/modulith/core/ApplicationModuleDetectionStrategyLookupTests.java
+++ b/spring-modulith-core/src/test/java/org/springframework/modulith/core/ApplicationModuleDetectionStrategyLookupTests.java
@@ -34,7 +34,7 @@ class ApplicationModuleDetectionStrategyLookupTests {
 		System.setProperty("spring.config.additional-location", "classpath:detection/explicitly-annotated.properties");
 
 		assertThat(ApplicationModuleDetectionStrategyLookup.getStrategy())
-				.isEqualTo(ApplicationModuleDetectionStrategy.explictlyAnnotated());
+				.isEqualTo(ApplicationModuleDetectionStrategy.explicitlyAnnotated());
 	}
 
 	@Test // GH-652

--- a/spring-modulith-core/src/test/java/org/springframework/modulith/core/ModuleDetectionStrategyUnitTest.java
+++ b/spring-modulith-core/src/test/java/org/springframework/modulith/core/ModuleDetectionStrategyUnitTest.java
@@ -38,7 +38,7 @@ class ModuleDetectionStrategyUnitTest {
 
 		var javaPackage = JavaPackage.of(Classes.of(classes), "jmolecules");
 
-		assertThat(ApplicationModuleDetectionStrategy.explictlyAnnotated().getModuleBasePackages(javaPackage))
+		assertThat(ApplicationModuleDetectionStrategy.explicitlyAnnotated().getModuleBasePackages(javaPackage))
 				.containsExactly(javaPackage);
 	}
 }


### PR DESCRIPTION
fixes typo in "explictlyAnnotated" by renaming it to "explicitlyAnnotated"