### PR TITLE
Wrong assert message of `HourHasPassed`

### DIFF
--- a/spring-modulith-moments/src/main/java/org/springframework/modulith/moments/HourHasPassed.java
+++ b/spring-modulith-moments/src/main/java/org/springframework/modulith/moments/HourHasPassed.java
@@ -40,7 +40,7 @@ public class HourHasPassed implements DomainEvent {
 	 */
 	private HourHasPassed(LocalDateTime time) {
 
-		Assert.notNull(time, "YearMonth must not be null!");
+		Assert.notNull(time, "LocalDateTime must not be null!");
 
 		this.time = time;
 	}


### PR DESCRIPTION
### Description

Fixing the assertion message of HourHasPassed to match with the method parameter.