### PR TITLE
Invalid package reference in `JacksonEventSerializer`

### DIFF
--- a/spring-modulith-events/spring-modulith-events-jackson/src/main/java/org/springframework/modulith/events/jackson/JacksonEventSerializer.java
+++ b/spring-modulith-events/spring-modulith-events-jackson/src/main/java/org/springframework/modulith/events/jackson/JacksonEventSerializer.java
@@ -47,7 +47,7 @@ class JacksonEventSerializer implements EventSerializer {
 
 	/*
 	 * (non-Javadoc)
-	 * @see de.oliverDrotbohm.events.EventSerializer#serialize(java.lang.Object)
+	 * @see org.springframework.modulith.events.core.EventSerializer#serialize(java.lang.Object)
 	 */
 	@Override
 	public Object serialize(Object event) {
@@ -61,7 +61,7 @@ class JacksonEventSerializer implements EventSerializer {
 
 	/*
 	 * (non-Javadoc)
-	 * @see de.oliverDrotbohm.events.EventSerializer#deserialize(java.lang.Object, java.lang.Class)
+	 * @see org.springframework.modulith.events.core.EventSerializer#deserialize(java.lang.Object, java.lang.Class)
 	 */
 	@Override
 	public <T> T deserialize(Object serialized, Class<T> type) {


### PR DESCRIPTION
I noticed that there was a reference to - I think - wrong package. This PR changes it to the correct package `org.springframework.modulith.events.core`