### PR TITLE
Fix a typo in the overview docs

### DIFF
--- a/src/docs/antora/modules/ROOT/pages/index.adoc
+++ b/src/docs/antora/modules/ROOT/pages/index.adoc
@@ -27,7 +27,7 @@ As a result, Spring Modulith enables developers to build applications that are e
 * Javadoc: https://docs.spring.io/spring-modulith/docs/{projectVersion}/api
 
 [[compatibility]]
-== Spring Boot compatbility
+== Spring Boot compatibility
 
 Find a full Spring Boot compatibility matrix xref:appendix.adoc#compatibility-matrix[here].
 


### PR DESCRIPTION
There was a tiny typo in the ["Overview" docs](https://docs.spring.io/spring-modulith/reference/index.html). 