### PR TITLE
GH-1295 - Replace HashMap with ConcurrentHashMap for thread safety

### DIFF
--- a/spring-modulith-core/src/main/java/org/springframework/modulith/core/PackageName.java
+++ b/spring-modulith-core/src/main/java/org/springframework/modulith/core/PackageName.java
@@ -16,9 +16,9 @@
 package org.springframework.modulith.core;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,7 +37,7 @@ public class PackageName implements Comparable<PackageName> {
 
 	public static final String DEFAULT = "<<default>>";
 
-	private static final Map<String, PackageName> PACKAGE_NAMES = new HashMap<>();
+	private static final Map<String, PackageName> PACKAGE_NAMES = new ConcurrentHashMap<>();
 
 	private final String name;
 	private final String[] segments;

--- a/spring-modulith-test/src/main/java/org/springframework/modulith/test/ModuleTestExecution.java
+++ b/spring-modulith-test/src/main/java/org/springframework/modulith/test/ModuleTestExecution.java
@@ -16,12 +16,12 @@
 package org.springframework.modulith.test;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,8 +51,8 @@ public class ModuleTestExecution implements Iterable<ApplicationModule> {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ModuleTestExecution.class);
 	private static final ApplicationModulesFactory BOOTSTRAP;
 
-	private static Map<Class<?>, Class<?>> MODULITH_TYPES = new HashMap<>();
-	private static Map<Key, ModuleTestExecution> EXECUTIONS = new HashMap<>();
+	private static final Map<Class<?>, Class<?>> MODULITH_TYPES = new ConcurrentHashMap<>();
+	private static final Map<Key, ModuleTestExecution> EXECUTIONS = new ConcurrentHashMap<>();
 
 	static {
 
@@ -84,7 +84,7 @@ public class ModuleTestExecution implements Iterable<ApplicationModule> {
 		this.basePackages = SingletonSupplier.of(() -> {
 
 			var moduleBasePackages = module.getBootstrapBasePackages(modules, bootstrapMode.getDepth());
-			var sharedBasePackages = modules.getSharedModules().stream().map(it -> it.getBasePackage());
+			var sharedBasePackages = modules.getSharedModules().stream().map(ApplicationModule::getBasePackage);
 			var extraPackages = extraIncludes.stream().map(ApplicationModule::getBasePackage);
 
 			var intermediate = Stream.concat(moduleBasePackages, extraPackages);

--- a/spring-modulith-test/src/test/java/org/springframework/modulith/test/ModuleTestExecutionUnitTests.java
+++ b/spring-modulith-test/src/test/java/org/springframework/modulith/test/ModuleTestExecutionUnitTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.test;
+
+import example.module.SampleTestA;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ModuleTestExecution}.
+ *
+ * @author Yevhenii Semenov
+ */
+class ModuleTestExecutionUnitTests {
+
+    @Test
+    void concurrentAccessToExecutionCacheIsSafe() throws InterruptedException {
+        int threadCount = 10;
+        var startBarrier = new CyclicBarrier(threadCount);
+        var completionLatch = new CountDownLatch(threadCount);
+        var errors = Collections.synchronizedList(new ArrayList<Exception>());
+        var executions = new ConcurrentHashMap<Integer, ModuleTestExecution>();
+
+        var executorService = Executors.newFixedThreadPool(threadCount);
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                int threadId = i;
+                executorService.submit(() -> {
+                    try {
+                        // Synchronize thread start for maximum contention
+                        startBarrier.await();
+
+                        // Get the execution
+                        var execution = ModuleTestExecution.of(SampleTestA.class).get();
+                        executions.put(threadId, execution);
+
+                    } catch (Exception e) {
+                        errors.add(e);
+                    } finally {
+                        completionLatch.countDown();
+                    }
+                });
+            }
+
+            // Wait for all threads to complete
+            assertThat(completionLatch.await(5, TimeUnit.SECONDS))
+                .as("All threads should complete within 5 seconds")
+                .isTrue();
+
+            // Check for errors
+            assertThat(errors)
+                .as("No exceptions during concurrent access")
+                .isEmpty();
+
+            // Verify all threads got the same cached instance
+            assertThat(executions).hasSize(threadCount);
+            var firstExecution = executions.get(0);
+            assertThat(executions.values())
+                .allSatisfy(execution -> assertThat(execution).isSameAs(firstExecution));
+
+        } finally {
+            executorService.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Replace static HashMap fields with ConcurrentHashMap in ModuleTestExecution and PackageName to ensure thread-safe access during concurrent test execution.

Closes gh-1295