### PR TITLE
Remove legacy reflection-based event handling in `PersistentApplicationEventMulticaster`

### DIFF
--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
@@ -250,7 +250,7 @@ public class PersistentApplicationEventMulticaster extends AbstractApplicationEv
 	private static boolean matches(ApplicationEvent event, Object payload, ApplicationListener<?> listener) {
 
 		// Verify general listener matching by eagerly evaluating the condition
-		if (!invokeShouldHandle(listener, event, payload)) {
+		if (!invokeShouldHandle(listener, event)) {
 			return false;
 		}
 
@@ -260,15 +260,14 @@ public class PersistentApplicationEventMulticaster extends AbstractApplicationEv
 	}
 
 	/**
-	 * Checks if the given listener should handle the specified event by invoking 
+	 * Checks if the given listener should handle the specified event by invoking
 	 * {@link ApplicationListenerMethodAdapter#shouldHandle(ApplicationEvent)} when applicable.
 	 *
 	 * @param candidate the listener to test, must not be {@literal null}.
 	 * @param event the event to publish, must not be {@literal null}.
-	 * @param payload the actual payload, must not be {@literal null}.
 	 * @return whether the event should be handled by the given candidate.
 	 */
-	private static boolean invokeShouldHandle(ApplicationListener<?> candidate, ApplicationEvent event, Object payload) {
+	private static boolean invokeShouldHandle(ApplicationListener<?> candidate, ApplicationEvent event) {
 
 		if (candidate instanceof ApplicationListenerMethodAdapter listener) {
 			return listener.shouldHandle(event);


### PR DESCRIPTION
# Description

The existing code appears to have been introduced during the transition from Spring 6.0.x to 6.1.x, when the public shouldHandle method was added to ApplicationListenerMethodAdapter. This code maintained backward compatibility with earlier versions of Spring by supporting both the new and legacy shouldHandle methods.

However, since Spring Modulith 2.0.0 will require Spring 7.0.0 or higher as a baseline, we can safely remove the logic related to backward compatibility with previous Spring versions.