### PR TITLE
Update copyright year in index.adoc

### DIFF
--- a/src/docs/antora/modules/ROOT/pages/index.adoc
+++ b/src/docs/antora/modules/ROOT/pages/index.adoc
@@ -5,7 +5,7 @@ Oliver Drotbohm
 :revdate: {localdate}
 :icons: font
 
-© 2022-2023 The original authors.
+© 2022-2025 The original authors.
 
 NOTE: Copies of this document may be made for your own use and for distribution to others, provided that you do not charge any fee for such copies and further provided that each copy contains this Copyright Notice, whether distributed in print or electronically.
 


### PR DESCRIPTION
While reviewing the Spring Modulith project documentation, I noticed that with the latest release of version 1.4.3 (2025), the copyright year in the reference documentation has not yet been updated.