### PR TITLE
GH-1386 - Detect Kotlin test sources

### DIFF
--- a/spring-modulith-apt/src/main/java/org/springframework/modulith/apt/SpringModulithProcessor.java
+++ b/spring-modulith-apt/src/main/java/org/springframework/modulith/apt/SpringModulithProcessor.java
@@ -134,7 +134,7 @@ public class SpringModulithProcessor implements Processor {
 
 			var path = placeholder.toUri().toString();
 
-			if (path.contains(BuildSystemUtils.getTestTarget())) {
+            if (BuildSystemUtils.isTestTarget(path)) {
 				this.testExecution = true;
 			}
 

--- a/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/util/BuildSystemUtils.java
+++ b/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/util/BuildSystemUtils.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.modulith.docs.util;
 
-import java.io.File;
-import java.util.Optional;
-
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * Utilities to detect the build system used.
@@ -54,12 +55,20 @@ public class BuildSystemUtils {
 	}
 
 	/**
-	 * Returns the path to the folder containing test classes.
+     * Whether the path to the folder contains test classes.
 	 *
+     * @param path must not be {@literal null} or empty.
 	 * @return will never be {@literal null}.
 	 */
-	public static String getTestTarget() {
-		return isMaven() ? "target/test-classes" : "build/classes/java/test";
+    public static boolean isTestTarget(String path) {
+
+        Assert.notNull(path, "Path must not be null!");
+
+        var pattern = isMaven()
+                ? Pattern.compile("^.*/target/test-classes/.*$")
+                : Pattern.compile("^.*/build(/.+)?/classes(/(java|kotlin))?/(test|testFixtures)/.*$");
+
+        return pattern.matcher(path).matches();
 	}
 
 	/**


### PR DESCRIPTION
Closes GH-1386

The `SpringModulithProcessor` detects test targets for Kotlin test sources in Gradle projects. Also sources from Gradle's [test fixtures](https://docs.gradle.org/current/userguide/java_testing.html#sec:java_test_fixtures) and kapt are included. So the processor should not run for targets like 

* `build/classes/java/test`
* `build/classes/kotlin/test`
* `build/tmp/kapt3/classes/testFixtures`

anymore.