### PR TITLE
GH-1382 - Add Kotlin support for Change-Aware Test Execution

### DIFF
--- a/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/diff/ModifiedFile.java
+++ b/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/diff/ModifiedFile.java
@@ -37,6 +37,13 @@ public record ModifiedFile(String path) {
 		return "java".equalsIgnoreCase(StringUtils.getFilenameExtension(path));
 	}
 
+	/**
+	 * Returns whether the modified file is Kotlin source file.
+	 */
+	public boolean isKotlinSource() {
+		return "kt".equalsIgnoreCase(StringUtils.getFilenameExtension(path));
+	}
+
 	public static Stream<ModifiedFile> of(String... paths) {
 		return Arrays.stream(paths).map(ModifiedFile::new);
 	}

--- a/spring-modulith-junit/src/test/java/org/springframework/modulith/junit/ChangesUnitTests.java
+++ b/spring-modulith-junit/src/test/java/org/springframework/modulith/junit/ChangesUnitTests.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.springframework.modulith.junit.Changes.Change.JavaSourceChange;
 import org.springframework.modulith.junit.Changes.Change.JavaTestSourceChange;
+import org.springframework.modulith.junit.Changes.Change.KotlinSourceChange;
+import org.springframework.modulith.junit.Changes.Change.KotlinTestSourceChange;
 import org.springframework.modulith.junit.Changes.Change.OtherFileChange;
 import org.springframework.modulith.junit.diff.ModifiedFile;
 
@@ -73,6 +75,8 @@ class ChangesUnitTests {
 		var modifiedFilePaths = Stream.of(
 				"src/main/java/org/springframework/modulith/junit/Changes.java",
 				"src/test/java/org/springframework/modulith/ChangesTest.java",
+				"src/test/kotlin/org/springframework/modulith/KotlinServiceTest.kt",
+				"src/main/kotlin/org/springframework/modulith/KotlinService.kt",
 				"src/main/resources/META-INF/additional-spring-configuration-metadata.json")
 				.map(ModifiedFile::new);
 
@@ -84,6 +88,8 @@ class ChangesUnitTests {
 		assertThat(result).containsExactlyInAnyOrder(
 				new JavaSourceChange("org.springframework.modulith.junit.Changes"),
 				new JavaTestSourceChange("org.springframework.modulith.ChangesTest"),
+				new KotlinTestSourceChange("org.springframework.modulith.KotlinServiceTest"),
+				new KotlinSourceChange("org.springframework.modulith.KotlinService"),
 				new OtherFileChange("src/main/resources/META-INF/additional-spring-configuration-metadata.json"));
 	}
 }


### PR DESCRIPTION
Previously Kotlin sources were converted to `OtherFileChanges` and therefore the optimization backed off which was the correct behaviour. Now Kotlin sources are converted to `KotlinSourceChange` and can be interpreted by the `TestExecutionCondition`.