### PR TITLE
Fix typo in reference documentation

### DIFF
--- a/src/docs/antora/modules/ROOT/pages/verification.adoc
+++ b/src/docs/antora/modules/ROOT/pages/verification.adoc
@@ -44,7 +44,7 @@ ApplicationModules.of(…)
   .throwIfPresent();
 ----
 
-== Customizing the Verifcation
+== Customizing the Verification
 
 As described xref:verification.adoc#verification[above], by default, both the `ApplicationModules.verify(…)` and `….detectViolations(…)` automatically perform additional verifications depending on the classpath configuration.
 


### PR DESCRIPTION
There was a small typo in the ["Verifying Application Module Structure" docs](https://docs.spring.io/spring-modulith/reference/verification.html), where "Verification" was misspelled as "Verifcation". 