### PR TITLE
GH-1386 - Adjust test target detection to KAPT specific paths

### DIFF
--- a/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/util/BuildSystemUtils.java
+++ b/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/util/BuildSystemUtils.java
@@ -92,7 +92,7 @@ public class BuildSystemUtils {
 	}
 
 	static boolean pointsToGradleTestTarget(String path) {
-		return path.matches("build(\\/.+)?\\/classes(\\/(java|kotlin))?\\/(test|testFixtures)\\/.*");
+		return path.matches("(.*\\/)?build(\\/.+)?\\/classes(\\/.+)?\\/(test|testFixtures)\\/.*");
 	}
 
 	private static String getTargetFolder() {

--- a/spring-modulith-docs/src/test/java/org/springframework/modulith/docs/util/BuildSystemUtilsUnitTests.java
+++ b/spring-modulith-docs/src/test/java/org/springframework/modulith/docs/util/BuildSystemUtilsUnitTests.java
@@ -45,7 +45,8 @@ class BuildSystemUtilsUnitTests {
 		var values = getSampleResources(
 				"build/classes/java/test",
 				"build/classes/kotlin/test",
-				"build/tmp/kapt3/classes/testFixtures");
+				"build/tmp/kapt3/classes/testFixtures",
+                "file:///full/path/to/project/build/tmp/kapt3/classes/test");
 
 		return DynamicTest.stream(values, it -> it + " is a test resource", it -> {
 			assertThat(BuildSystemUtils.pointsToGradleTestTarget(it)).isTrue();


### PR DESCRIPTION
Changed the regex for test-source detection. It matches also full paths and KAPT-specific directories now.

I removed the exact matching for `java`- / `kotlin`-directories, because KAPT does not use them and processes files in `/tmp/kapt3`. 

Closes gh-1386