### PR TITLE
Invalid type reference in check for jMolecules Onion Architecture integration presence

### DIFF
--- a/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Groupings.java
+++ b/spring-modulith-docs/src/main/java/org/springframework/modulith/docs/Groupings.java
@@ -95,7 +95,7 @@ public class Groupings {
 				.isPresent("org.jmolecules.architecture.layered.ApplicationLayer", JMoleculesGroupings.class.getClassLoader());
 
 		private static final boolean JMOLECULES_ONION_PRESENT = ClassUtils
-				.isPresent("org.jmolecules.architecture.onion.classical.ApplicationRing",
+				.isPresent("org.jmolecules.architecture.onion.simplified.ApplicationRing",
 						JMoleculesGroupings.class.getClassLoader());
 
 		public static Grouping[] getGroupings() {


### PR DESCRIPTION
The `ApplicationRing` class is checked with an incorrect package.