### PR TITLE
Add version catalogue files to JUnit change detection

### DIFF
--- a/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/Changes.java
+++ b/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/Changes.java
@@ -291,6 +291,7 @@ public class Changes implements Iterable<Change> {
 
 					// Gradle
 					"build.gradle", "build.gradle.kts", "gradle.properties", "settings.gradle", "settings.gradle.kts",
+                    "libs.versions.toml",
 
 					// Maven
 					"pom.xml");

--- a/spring-modulith-junit/src/test/java/org/springframework/modulith/junit/ChangesUnitTests.java
+++ b/spring-modulith-junit/src/test/java/org/springframework/modulith/junit/ChangesUnitTests.java
@@ -57,7 +57,8 @@ class ChangesUnitTests {
 				"pom.xml",
 
 				// Gradle
-				"build.gradle", "build.gradle.kts", "gradle.properties", "settings.gradle", "settings.gradle.kts");
+				"build.gradle", "build.gradle.kts", "gradle.properties", "settings.gradle", "settings.gradle.kts",
+                "libs.versions.toml");
 
 		return DynamicTest.stream(files, it -> it + " is considered build resource", it -> {
 


### PR DESCRIPTION
We are using [Gradle's Version Catalogue](https://docs.gradle.org/current/userguide/version_catalogs.html) in our project to specify dependencies outside of the `build.gradle(.kts)`. Instead, all dependencies and their versions are located in a `gradle/libs.versions.toml` file. Currently, this file is not included in the specified build files for the change detection. The JUnit extension from `spring-modulith-junit` will not detect changes in those files and therefore version updates will not back off the optimization of the module test execution.

I prepared this PR so the `libs.versions.toml` file is recognized by `OtherFileChange`.