### PR TITLE
GH-1123 - Detect events configured for externalization published outside a transaction

### DIFF
--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/EventPublicationAutoConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/EventPublicationAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Role;
 import org.springframework.core.env.Environment;
+import org.springframework.modulith.events.EventExternalizationConfiguration;
 import org.springframework.modulith.events.config.EventPublicationAutoConfiguration.AsyncEnablingConfiguration;
 import org.springframework.modulith.events.core.DefaultEventPublicationRegistry;
 import org.springframework.modulith.events.core.EventPublicationRegistry;
@@ -74,9 +75,11 @@ public class EventPublicationAutoConfiguration extends EventPublicationConfigura
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	@ConditionalOnBean(EventPublicationRegistry.class)
 	static PersistentApplicationEventMulticaster applicationEventMulticaster(
-			ObjectFactory<EventPublicationRegistry> eventPublicationRegistry, ObjectFactory<Environment> environment) {
+			ObjectFactory<EventPublicationRegistry> eventPublicationRegistry, ObjectFactory<Environment> environment,
+			ObjectProvider<EventExternalizationConfiguration> externalizationConfiguration) {
 
-		return EventPublicationConfiguration.applicationEventMulticaster(eventPublicationRegistry, environment);
+		return EventPublicationConfiguration.applicationEventMulticaster(eventPublicationRegistry, environment,
+				externalizationConfiguration);
 	}
 
 	@Bean

--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/EventPublicationConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/EventPublicationConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
 import org.springframework.core.env.Environment;
+import org.springframework.modulith.events.EventExternalizationConfiguration;
 import org.springframework.modulith.events.core.DefaultEventPublicationRegistry;
 import org.springframework.modulith.events.core.EventPublicationRegistry;
 import org.springframework.modulith.events.core.EventPublicationRepository;
@@ -51,10 +52,12 @@ class EventPublicationConfiguration {
 	@Bean
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	static PersistentApplicationEventMulticaster applicationEventMulticaster(
-			ObjectFactory<EventPublicationRegistry> eventPublicationRegistry, ObjectFactory<Environment> environment) {
+			ObjectFactory<EventPublicationRegistry> eventPublicationRegistry, ObjectFactory<Environment> environment,
+			ObjectProvider<EventExternalizationConfiguration> externalizationConfiguration) {
 
 		return new PersistentApplicationEventMulticaster(() -> eventPublicationRegistry.getObject(),
-				() -> environment.getObject());
+				() -> environment.getObject(),
+				() -> externalizationConfiguration.getIfAvailable(EventExternalizationConfiguration::disabled));
 	}
 
 	@Bean


### PR DESCRIPTION
## Summary

Events configured for externalization via `@Externalized` silently fail when published outside a transaction context — they are neither persisted nor externalized. This can be difficult to diagnose.

This change adds a warning log in `PersistentApplicationEventMulticaster` to detect this scenario and inform developers with actionable guidance.

Fixes #1123

## Changes

- Add `EventExternalizationConfiguration` as an optional dependency to `PersistentApplicationEventMulticaster` with a backward-compatible two-argument constructor overload
- Add `detectEventPublishedOutsideTransaction()` that logs a warning when:
  1. No active transaction is present
  2. Transactional event listeners exist for the event
  3. The event is configured for externalization
- Wire `ObjectProvider<EventExternalizationConfiguration>` through `EventPublicationConfiguration` and `EventPublicationAutoConfiguration`
- Add Javadoc to `TransactionalEventListeners.hasListeners()`

## Test plan

- 4 new unit tests covering all branches:
  - Warns when externalization event published outside transaction
  - Does not warn inside an active transaction
  - Does not warn for non-externalization events
  - Does not warn when no transactional listeners exist
- All existing module tests pass