### PR TITLE
Fixing links to reference documentation in README

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -1,9 +1,9 @@
 = Spring Modulith image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Develocity", link="https://ge.spring.io/scans?search.rootProjectNames=Spring Modulith"]
 
-:docs: https://docs.spring.io/spring-modulith/docs/current-SNAPSHOT/reference/html/
+:docs: https://docs.spring.io/spring-modulith/reference/
 
-Spring Modulith allows developers to build well-structured Spring Boot applications and guides developers in finding and working with link:{docs}#fundamentals.modules.application-modules[application modules] driven by the domain.
-It supports the link:{docs}#verification[verification] of such modular arrangements, link:{docs}#testing[integration testing] individual modules, link:{docs}#observability[observing] the application's behavior on the module level and creating link:{docs}#documentation[documentation snippets] based on the arrangement created.
+Spring Modulith allows developers to build well-structured Spring Boot applications and guides developers in finding and working with link:{docs}fundamentals.html#modules[application modules] driven by the domain.
+It supports the link:{docs}verification.html[verification] of such modular arrangements, link:{docs}testing.html[integration testing] individual modules, link:{docs}production-ready.html#observability[observing] the application's behavior on the module level and creating link:{docs}documentation.html[documentation snippets] based on the arrangement created.
 
 == Quickstart
 
@@ -18,7 +18,7 @@ It supports the link:{docs}#verification[verification] of such modular arrangeme
     <dependency>
       <groupId>org.springframework.modulith</groupId>
       <artifactId>spring-modulith-bom</artifactId>
-      <version>1.3.1</version>
+      <version>2.0.2</version>
       <scope>import</scope>
       <type>pom</type>
     </dependency>
@@ -37,7 +37,7 @@ It supports the link:{docs}#verification[verification] of such modular arrangeme
 
 </dependencies>
 ----
-. Create a Java package arrangement that puts business modules as link:{docs}#fundamentals[direct sub-packages of the application's main package].
+. Create a Java package arrangement that puts business modules as link:{docs}fundamentals.html[direct sub-packages of the application's main package].
 +
 [source, text, subs="macros"]
 ----
@@ -52,7 +52,7 @@ It supports the link:{docs}#verification[verification] of such modular arrangeme
 ----
 <1> The application root package
 <2> Application module packages
-. Create link:{docs}#fundamentals.modules.application-modules[an `ApplicationModules` model], run link:{docs}#verification[verifications] and link:{docs}#documentation[create documentation snippets].
+. Create link:{docs}fundamentals.html#modules[an `ApplicationModules` model], run link:{docs}verification.html[verifications] and link:{docs}documentation.html[create documentation snippets].
 +
 [source, java]
 ----
@@ -69,9 +69,9 @@ class ApplicationTests {
   }
 }
 ----
-<1> Creates application module model and link:{docs}#verification[verifies its structure].
-<2> Renders link:{docs}#documentation[Asciidoctor snippets] (component diagrams, application module canvas) to `target/modulith-docs`.
-. Run link:{docs}#testing[integration tests] for individual application modules.
+<1> Creates application module model and link:{docs}verification.html[verifies its structure].
+<2> Renders link:{docs}documentation.html[Asciidoctor snippets] (component diagrams, application module canvas) to `target/modulith-docs`.
+. Run link:{docs}testing.html[integration tests] for individual application modules.
 +
 [source, text, subs="macros"]
 ----


### PR DESCRIPTION
- Links were broken because the redirects on the old documentation page did not consider the anchors/#hashtags
- Updated version for the spring-modulith-bom to tomorrow's release version 2.0.2