### PR TITLE
GH-1513 - Propagate delegate when executor threads are already created

### DIFF
--- a/spring-modulith-test/src/test/java/org/springframework/modulith/test/PublishedEventsIntegrationTests.java
+++ b/spring-modulith-test/src/test/java/org/springframework/modulith/test/PublishedEventsIntegrationTests.java
@@ -60,6 +60,7 @@ class PublishedEventsIntegrationTests {
 	}
 
 	@Test // #116
+	@Order(2)
 	void capturesEventsTriggeredByAsyncEventListeners(PublishedEvents events) {
 
 		assertThatNoException().isThrownBy(() -> {


### PR DESCRIPTION
There is an ordering issue: when task threads are created before `ThreadBoundApplicationListenerAdapter` is initialized,  `InheritableThreadLocal` values are not propagated.

As a result, later events bypass the test context. Because thread creation timing is nondeterministic, this leads to flaky tests as expected events are not detected.

Fixes GH-1513
