### PR TITLE
GH-1554 - include contributed package classes in ApplicationModules allClasses

### DIFF
--- a/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModuleSourceContributions.java
+++ b/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModuleSourceContributions.java
@@ -56,6 +56,12 @@ class ApplicationModuleSourceContributions {
 				defaultStrategy, useFullyQualifiedModuleNames);
 	}
 
+	static ApplicationModuleSourceContributions of(List<? extends ApplicationModuleSourceFactory> factories,
+			Function<Collection<String>, JavaClasses> importer,
+			ApplicationModuleDetectionStrategy defaultStrategy, boolean useFullyQualifiedModuleNames) {
+		return new ApplicationModuleSourceContributions(factories, importer, defaultStrategy, useFullyQualifiedModuleNames);
+	}
+
 	/**
 	 * Creates a new {@link ApplicationModuleSourceContributions} for the given {@link ApplicationModuleSourceFactory}s,
 	 * importer function, default {@link ApplicationModuleDetectionStrategy} and whether to use fully-qualified module

--- a/spring-modulith-integration-test/src/test/java/org/springframework/modulith/core/ApplicationModulesIntegrationTest.java
+++ b/spring-modulith-integration-test/src/test/java/org/springframework/modulith/core/ApplicationModulesIntegrationTest.java
@@ -17,6 +17,8 @@ package org.springframework.modulith.core;
 
 import static org.assertj.core.api.Assertions.*;
 
+import contributed.detected.DetectedContribution;
+import contributed.enumerated.EnumeratedContribution;
 import example.declared.first.First;
 import example.declared.fourth.Fourth;
 import example.declared.second.Second;
@@ -255,6 +257,26 @@ class ApplicationModulesIntegrationTest {
 
 			assertThat(modules.getModuleByName("detected")).isNotEmpty();
 			assertThat(modules.getModuleByName("enumerated")).isNotEmpty();
+
+		} finally {
+			ApplicationModuleSourceContributions.LOCATION = location;
+		}
+	}
+
+	@Test // GH-1554
+	void doesNotFailCycleDetectionForContributedApplicationModules() {
+
+		var location = ApplicationModuleSourceContributions.LOCATION;
+
+		ApplicationModuleSourceContributions.LOCATION = "META-INF/spring-test.factories";
+
+		try {
+
+			var modules = org.springframework.modulith.test.TestUtils.createApplicationModules(Application.class);
+
+			assertThat(modules.contains(DetectedContribution.class)).isTrue();
+			assertThat(modules.contains(EnumeratedContribution.class)).isTrue();
+			assertThatNoException().isThrownBy(modules::detectViolations);
 
 		} finally {
 			ApplicationModuleSourceContributions.LOCATION = location;


### PR DESCRIPTION
## Summary
  Fix `ApplicationModules.detectViolations(...)` failing with `ApplicationModuleSourceFactory` contributions
  when cycle checks are evaluated.

  ## Problem
  When modules are contributed from `ApplicationModuleSourceFactory` root packages, those packages could
  appear in `rootPackages` but not in `allClasses`.
  `detectViolations()` then runs cycle checks per root package and may fail with ArchUnit `empty should`
  (`failed to check any classes`).

  ## Solution
  - Include factory-contributed root packages when building `allClasses`.
  - Reuse the same `JavaClasses` graph for contribution processing (instead of re-importing), then select
  package subsets from it.

  ## Changes
  - `spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModules.java`
    - Load `ApplicationModuleSourceFactory` instances up front.
    - Import base + contributed root packages into `allClasses`.
    - Use `ApplicationModuleSourceContributions.of(factories, ...)`.
    - Add `filterByPackages(...)` helper.
  - `spring-modulith-core/src/main/java/org/springframework/modulith/core/
  ApplicationModuleSourceContributions.java`
    - Add `of(List<? extends ApplicationModuleSourceFactory>, ...)` overload.
  - `spring-modulith-integration-test/src/test/java/org/springframework/modulith/core/
  ApplicationModulesIntegrationTest.java`
    - Add regression test:
      - `doesNotFailCycleDetectionForContributedApplicationModules()`

  Closes #1554