### PR TITLE
Block for externalization in outbox mode

### DIFF
--- a/spring-modulith-events/spring-modulith-events-amqp/src/main/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-amqp/src/main/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfiguration.java
@@ -19,6 +19,7 @@ import io.namastack.outbox.handler.OutboxHandler;
 
 import java.util.concurrent.CompletableFuture;
 
+import java.util.concurrent.ExecutionException;
 import org.jobrunr.scheduling.JobScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +93,16 @@ class RabbitEventExternalizerConfiguration {
 
 				var externalizer = factory.forTransport(transport);
 
-				return (payload, metadata) -> externalizer.externalize(payload);
+				return (payload, metadata) -> {
+					try {
+						externalizer.externalize(payload).get();
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new RuntimeException(e);
+					} catch (ExecutionException e) {
+						throw new RuntimeException(e.getCause());
+					}
+				};
 			}
 		}
 

--- a/spring-modulith-events/spring-modulith-events-jms/src/main/java/org/springframework/modulith/events/jms/JmsEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-jms/src/main/java/org/springframework/modulith/events/jms/JmsEventExternalizerConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.modulith.events.jms;
 import io.namastack.outbox.handler.OutboxHandler;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.jobrunr.scheduling.JobScheduler;
 import org.slf4j.Logger;
@@ -86,13 +87,22 @@ class JmsEventExternalizerConfiguration {
 		@ConditionalOnClass(OutboxHandler.class)
 		class NamastackOutboxAutoConfiguration {
 
-			@Bean
-			OutboxHandler namastackJmsOutboxExternalizer() {
+		@Bean
+		OutboxHandler namastackJmsOutboxExternalizer() {
 
-				logger.debug("Registering Namastack domain event outbox externalization to JMS.");
+			logger.debug("Registering Namastack domain event outbox externalization to JMS.");
 
-				return (payload, metadata) -> externalizer.externalize(payload);
-			}
+			return (payload, metadata) -> {
+				try {
+					externalizer.externalize(payload).get();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new RuntimeException(e);
+				} catch (ExecutionException e) {
+					throw new RuntimeException(e.getCause());
+				}
+			};
+		}
 		}
 
 		@AutoConfiguration

--- a/spring-modulith-events/spring-modulith-events-kafka/src/main/java/org/springframework/modulith/events/kafka/KafkaEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-kafka/src/main/java/org/springframework/modulith/events/kafka/KafkaEventExternalizerConfiguration.java
@@ -17,6 +17,8 @@ package org.springframework.modulith.events.kafka;
 
 import io.namastack.outbox.handler.OutboxHandler;
 
+import java.util.concurrent.ExecutionException;
+
 import org.jobrunr.scheduling.JobScheduler;
 import org.jspecify.annotations.NullUnmarked;
 import org.slf4j.Logger;
@@ -89,13 +91,22 @@ class KafkaEventExternalizerConfiguration {
 		@ConditionalOnClass(OutboxHandler.class)
 		class NamastackOutboxAutoConfiguration {
 
-			@Bean
-			OutboxHandler namastackKafkaOutboxExternalizer(OutboxEventExternalizerFactory factory) {
+		@Bean
+		OutboxHandler namastackKafkaOutboxExternalizer(OutboxEventExternalizerFactory factory) {
 
-				logger.debug("Registering Namastack domain event outbox externalization to Kafka.");
+			logger.debug("Registering Namastack domain event outbox externalization to Kafka.");
 
-				return (payload, metadata) -> externalizer.externalize(payload);
-			}
+			return (payload, metadata) -> {
+				try {
+					externalizer.externalize(payload).get();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new RuntimeException(e);
+				} catch (ExecutionException e) {
+					throw new RuntimeException(e.getCause());
+				}
+			};
+		}
 		}
 
 		@AutoConfiguration

--- a/spring-modulith-events/spring-modulith-events-messaging/src/main/java/org/springframework/modulith/events/messaging/SpringMessagingEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-messaging/src/main/java/org/springframework/modulith/events/messaging/SpringMessagingEventExternalizerConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.modulith.events.messaging;
 import io.namastack.outbox.handler.OutboxHandler;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.jobrunr.scheduling.JobScheduler;
 import org.slf4j.Logger;
@@ -86,13 +87,22 @@ class SpringMessagingEventExternalizerConfiguration {
 		@ConditionalOnClass(OutboxHandler.class)
 		class NamastackOutboxAutoConfiguration {
 
-			@Bean
-			OutboxHandler namastackKafkaOutboxExternalizer() {
+		@Bean
+		OutboxHandler namastackKafkaOutboxExternalizer() {
 
-				logger.debug("Registering Namastack domain event outbox externalization for Spring Messaging.");
+			logger.debug("Registering Namastack domain event outbox externalization for Spring Messaging.");
 
-				return (payload, metadata) -> externalizer.externalize(payload);
-			}
+			return (payload, metadata) -> {
+				try {
+					externalizer.externalize(payload).get();
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					throw new RuntimeException(e);
+				} catch (ExecutionException e) {
+					throw new RuntimeException(e.getCause());
+				}
+			};
+		}
 		}
 
 		@AutoConfiguration


### PR DESCRIPTION
# Fix synchronous handling for Outbox event externalization across transport configurations

## Summary

This PR ensures that Outbox event externalization is handled synchronously across all supported messaging transport modules (AMQP, JMS, Kafka, and Spring Messaging). The Outbox handler implementations now block until the externalization is complete and properly propagate exceptions.

## Details

- **Modules affected:**
  - `spring-modulith-events-amqp`
  - `spring-modulith-events-jms`
  - `spring-modulith-events-kafka`
  - `spring-modulith-events-messaging`

- **What was changed:**
  - The Outbox handler in each transport configuration now calls `.get()` on the returned `CompletableFuture` to ensure synchronous execution.
  - Exceptions (`InterruptedException`, `ExecutionException`) are caught and rethrown as `RuntimeException`, with the thread interrupt status restored as appropriate.
  - This guarantees that failures during event externalization are not silently ignored and are surfaced to the caller.

## Why

- To provide consistent, reliable, and predictable event externalization semantics across all messaging modules.
- To ensure that errors during outbox processing are not lost and can be handled by the application.