### PR TITLE
GH-1703 - Simplify JPA publication status defaulting

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,10 @@ jobs:
     steps:
 
     - name: Check out sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: 21

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository_owner == 'spring-projects'
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: docs-build
         fetch-depth: 1

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -35,7 +35,7 @@ jobs:
           ref: ${{ matrix.branch }}
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: 17

--- a/.github/workflows/milestone.yaml
+++ b/.github/workflows/milestone.yaml
@@ -34,7 +34,7 @@ jobs:
       run: ./mvnw -B clean deploy -Pci,artifactory
 
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v1
+      uses: ts-graphviz/setup-graphviz@v2
 
     - name: Deploy documentation
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         ./mvnw -B clean deploy -Pci,sonatype -s settings.xml
 
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v1
+      uses: ts-graphviz/setup-graphviz@v2
 
     - name: Deploy documentation
       env:

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<jmolecules-bom.version>2025.0.2</jmolecules-bom.version>
 		<jobrunr.version>8.5.2</jobrunr.version>
 		<json-unit-assertj.version>5.1.1</json-unit-assertj.version>
-		<namastack-outbox.version>1.5.0</namastack-outbox.version>
+		<namastack-outbox.version>1.6.0</namastack-outbox.version>
 		<nullaway.version>0.13.0</nullaway.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<flapdoodle-mongodb.version>4.20.0</flapdoodle-mongodb.version>
 		<jgit.version>7.6.0.202603022253-r</jgit.version>
 		<jmolecules-bom.version>2025.0.2</jmolecules-bom.version>
-		<jobrunr.version>8.5.2</jobrunr.version>
+		<jobrunr.version>8.6.0</jobrunr.version>
 		<json-unit-assertj.version>5.1.1</json-unit-assertj.version>
 		<namastack-outbox.version>1.6.0</namastack-outbox.version>
 		<nullaway.version>0.13.0</nullaway.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<jmolecules-bom.version>2025.0.2</jmolecules-bom.version>
 		<jobrunr.version>8.5.2</jobrunr.version>
 		<json-unit-assertj.version>5.1.1</json-unit-assertj.version>
-		<namastack-outbox.version>1.4.0</namastack-outbox.version>
+		<namastack-outbox.version>1.5.0</namastack-outbox.version>
 		<nullaway.version>0.13.0</nullaway.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/spring-modulith-apt/src/test/java/org/springframework/modulith/apt/SpringModulithProcessorUnitTests.java
+++ b/spring-modulith-apt/src/test/java/org/springframework/modulith/apt/SpringModulithProcessorUnitTests.java
@@ -24,8 +24,11 @@ import io.toolisticon.cute.CuteApi.BlackBoxTestSourceFilesAndProcessorInterface;
 import io.toolisticon.cute.CuteApi.DoCustomAssertions;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.json.BasicJsonParser;
 
 import com.jayway.jsonpath.JsonPath;
 
@@ -69,6 +72,27 @@ class SpringModulithProcessorUnitTests {
 		assertThatNoException().isThrownBy(() -> {
 			assertSucceded(getSourceFile("SampleInterface"));
 		});
+	}
+
+	@Test // GH-1685
+	void javadocWithDoubleQuotesProducesValidJson() throws Exception {
+
+		assertSucceded(getSourceFile("SampleComponentWithQuotes"));
+
+		var content = Files.readString(new File(JSON_LOCATION).toPath(), StandardCharsets.UTF_8);
+
+		assertThatNoException()
+				.as("BasicJsonParser must be able to parse the generated JSON without errors")
+				.isThrownBy(() -> new BasicJsonParser().parseList(content));
+
+		var context = JsonPath.parse(new File(JSON_LOCATION));
+		var comment = context.read(
+				"$[?(@.name == 'example.SampleComponentWithQuotes')].methods[0].comment",
+				String[].class)[0];
+
+		assertThat(comment)
+				.as("Javadoc comment must preserve literal double-quote characters")
+				.contains("\"foo\"", "\"bar\"");
 	}
 
 	@Test // GH-1430

--- a/spring-modulith-apt/src/test/resources/example/SampleComponentWithQuotes.java
+++ b/spring-modulith-apt/src/test/resources/example/SampleComponentWithQuotes.java
@@ -1,0 +1,16 @@
+package example;
+
+/**
+ * Component whose method Javadoc contains literal double-quote characters.
+ */
+class SampleComponentWithQuotes {
+
+	/**
+	 * Finds something by key. Example:
+	 *
+	 * <pre>
+	 * findByKey("foo", "bar")
+	 * </pre>
+	 */
+	void findByKey(String a, String b) {}
+}

--- a/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModules.java
+++ b/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModules.java
@@ -458,7 +458,7 @@ public class ApplicationModules implements Iterable<ApplicationModule> {
 	}
 
 	/**
-	 * Executes all verifications to be applied and returns {@link Violations} if any occured. Will always execute the
+	 * Executes all verifications to be applied and returns {@link Violations} if any occurred. Will always execute the
 	 * verifications in contrast to {@link #verify()} which just runs once.
 	 *
 	 * @return will never be {@literal null}.
@@ -470,7 +470,7 @@ public class ApplicationModules implements Iterable<ApplicationModule> {
 
 	/**
 	 * Executes all verifications to be applied considering the given {@link VerificationOptions} and returns
-	 * {@link Violations} if any occured. Will always execute the verifications in contrast to {@link #verify()} which
+	 * {@link Violations} if any occurred. Will always execute the verifications in contrast to {@link #verify()} which
 	 * just runs once.
 	 *
 	 * @return will never be {@literal null}.

--- a/spring-modulith-events/spring-modulith-events-amqp/src/main/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-amqp/src/main/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.modulith.events.jobrunr.JobRunrExternalizationTranspo
 import org.springframework.modulith.events.support.BrokerRouting;
 import org.springframework.modulith.events.support.EventExternalizationTransport;
 import org.springframework.modulith.events.support.EventExternalizerModuleListener;
+import org.springframework.modulith.events.support.OutboxEventExternalizer;
 import org.springframework.modulith.events.support.OutboxEventExternalizerFactory;
 
 /**
@@ -73,12 +74,12 @@ class RabbitEventExternalizerConfiguration {
 	@ConditionalOnProperty(name = ExternalizationMode.PROPERTY, havingValue = "outbox")
 	static class RabbitOutboxConfiguration {
 
-		private final EventExternalizationTransport transport;
+		private final OutboxEventExternalizer externalizer;
 
 		RabbitOutboxConfiguration(EventExternalizationConfiguration configuration, RabbitMessageOperations operations,
-				BeanFactory beanFactory) {
+				BeanFactory beanFactory, OutboxEventExternalizerFactory factory) {
 
-			this.transport = createRabbitTransport(configuration, operations, beanFactory);
+			this.externalizer = factory.forTransport(createRabbitTransport(configuration, operations, beanFactory));
 		}
 
 		@AutoConfiguration
@@ -86,13 +87,11 @@ class RabbitEventExternalizerConfiguration {
 		class NamastackOutboxAutoConfiguration {
 
 			@Bean
-			OutboxHandler kafkaOutboxExternalizer(OutboxEventExternalizerFactory factory) {
+			OutboxHandler kafkaOutboxExternalizer() {
 
 				logger.debug("Registering Namastack domain event outbox externalization to RabbitMQ.");
 
-				var externalizer = factory.forTransport(transport);
-
-				return (payload, metadata) -> externalizer.externalize(payload);
+				return (payload, metadata) -> externalizer.externalizeBlocking(payload);
 			}
 		}
 
@@ -101,13 +100,11 @@ class RabbitEventExternalizerConfiguration {
 		class JobRunrOutboxAutoConfiguration {
 
 			@Bean
-			JobRunrExternalizationTransport jobRunrOutboxExternalizer(OutboxEventExternalizerFactory factory) {
+			JobRunrExternalizationTransport jobRunrOutboxExternalizer() {
 
 				logger.debug("Registering JobRunr domain event outbox externalization to RabbitMQ.");
 
-				var externalizer = factory.forTransport(transport);
-
-				return payload -> externalizer.externalize(payload);
+				return payload -> externalizer.externalizeBlocking(payload);
 			}
 		}
 	}

--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/OutboxEventExternalizer.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/OutboxEventExternalizer.java
@@ -16,6 +16,7 @@
 package org.springframework.modulith.events.support;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.modulith.events.EventExternalizationConfiguration;
@@ -64,5 +65,25 @@ public class OutboxEventExternalizer extends TransportAwareEventExternalizer {
 			events.publishEvent(it);
 			return it;
 		});
+	}
+
+	/**
+	 * Externalizes the given event in a blocking way.
+	 *
+	 * @param event must not be {@literal null}.
+	 * @see #externalize(Object)
+	 */
+	public void externalizeBlocking(Object event) {
+
+		try {
+
+			externalize(event).get();
+
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new RuntimeException(e);
+		} catch (ExecutionException e) {
+			throw new RuntimeException(e.getCause());
+		}
 	}
 }

--- a/spring-modulith-events/spring-modulith-events-jms/src/main/java/org/springframework/modulith/events/jms/JmsEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-jms/src/main/java/org/springframework/modulith/events/jms/JmsEventExternalizerConfiguration.java
@@ -91,7 +91,7 @@ class JmsEventExternalizerConfiguration {
 
 				logger.debug("Registering Namastack domain event outbox externalization to JMS.");
 
-				return (payload, metadata) -> externalizer.externalize(payload);
+				return (payload, metadata) -> externalizer.externalizeBlocking(payload);
 			}
 		}
 
@@ -104,7 +104,7 @@ class JmsEventExternalizerConfiguration {
 
 				logger.debug("Registering JobRunr domain event outbox externalization to JMS.");
 
-				return externalizer::externalize;
+				return externalizer::externalizeBlocking;
 			}
 		}
 	}

--- a/spring-modulith-events/spring-modulith-events-jpa/src/main/java/org/springframework/modulith/events/jpa/JpaEventPublication.java
+++ b/spring-modulith-events/spring-modulith-events-jpa/src/main/java/org/springframework/modulith/events/jpa/JpaEventPublication.java
@@ -78,7 +78,7 @@ public abstract class JpaEventPublication {
 		this.listenerId = listenerId;
 		this.serializedEvent = serializedEvent;
 		this.eventType = eventType;
-		this.status = status != null ? status : completionDate != null ? Status.COMPLETED : Status.PROCESSING;
+		this.status = status != null ? status : Status.PROCESSING;
 		this.lastResubmissionDate = lastResubmissionDate;
 		this.completionAttempts = completionAttempts;
 	}

--- a/spring-modulith-events/spring-modulith-events-kafka/src/main/java/org/springframework/modulith/events/kafka/KafkaEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-kafka/src/main/java/org/springframework/modulith/events/kafka/KafkaEventExternalizerConfiguration.java
@@ -90,11 +90,11 @@ class KafkaEventExternalizerConfiguration {
 		class NamastackOutboxAutoConfiguration {
 
 			@Bean
-			OutboxHandler namastackKafkaOutboxExternalizer(OutboxEventExternalizerFactory factory) {
+			OutboxHandler namastackKafkaOutboxExternalizer() {
 
 				logger.debug("Registering Namastack domain event outbox externalization to Kafka.");
 
-				return (payload, metadata) -> externalizer.externalize(payload);
+				return (payload, metadata) -> externalizer.externalizeBlocking(payload);
 			}
 		}
 
@@ -103,11 +103,11 @@ class KafkaEventExternalizerConfiguration {
 		class JobRunrOutboxAutoConfiguration {
 
 			@Bean
-			JobRunrExternalizationTransport jobRunrKafkaOutboxExternalizer(OutboxEventExternalizerFactory factory) {
+			JobRunrExternalizationTransport jobRunrKafkaOutboxExternalizer() {
 
 				logger.debug("Registering JobRunr domain event outbox externalization to Kafka.");
 
-				return payload -> externalizer.externalize(payload);
+				return payload -> externalizer.externalizeBlocking(payload);
 			}
 		}
 	}

--- a/spring-modulith-events/spring-modulith-events-messaging/src/main/java/org/springframework/modulith/events/messaging/SpringMessagingEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-messaging/src/main/java/org/springframework/modulith/events/messaging/SpringMessagingEventExternalizerConfiguration.java
@@ -91,7 +91,7 @@ class SpringMessagingEventExternalizerConfiguration {
 
 				logger.debug("Registering Namastack domain event outbox externalization for Spring Messaging.");
 
-				return (payload, metadata) -> externalizer.externalize(payload);
+				return (payload, metadata) -> externalizer.externalizeBlocking(payload);
 			}
 		}
 
@@ -104,7 +104,7 @@ class SpringMessagingEventExternalizerConfiguration {
 
 				logger.debug("Registering JobRunr domain event outbox externalization for Spring Messaging.");
 
-				return externalizer::externalize;
+				return externalizer::externalizeBlocking;
 			}
 		}
 	}

--- a/spring-modulith-runtime/pom.xml
+++ b/spring-modulith-runtime/pom.xml
@@ -87,6 +87,42 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-jdbc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-jpa-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-r2dbc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		
+		<dependency>
+			<groupId>io.r2dbc</groupId>
+			<artifactId>r2dbc-h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-jooq-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-jpa-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 	
 	<build>

--- a/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.data.jdbc.test.autoconfigure.AutoConfigureDataJdbc.imports
+++ b/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.data.jdbc.test.autoconfigure.AutoConfigureDataJdbc.imports
@@ -1,0 +1,1 @@
+org.springframework.modulith.runtime.autoconfigure.SpringModulithRuntimeAutoConfiguration

--- a/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.data.jpa.test.autoconfigure.AutoConfigureDataJpa.imports
+++ b/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.data.jpa.test.autoconfigure.AutoConfigureDataJpa.imports
@@ -1,0 +1,1 @@
+org.springframework.modulith.runtime.autoconfigure.SpringModulithRuntimeAutoConfiguration

--- a/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.data.r2dbc.test.autoconfigure.AutoConfigureDataR2dbc.imports
+++ b/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.data.r2dbc.test.autoconfigure.AutoConfigureDataR2dbc.imports
@@ -1,0 +1,1 @@
+org.springframework.modulith.runtime.autoconfigure.SpringModulithRuntimeAutoConfiguration

--- a/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureJdbc.imports
+++ b/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureJdbc.imports
@@ -1,0 +1,1 @@
+org.springframework.modulith.runtime.autoconfigure.SpringModulithRuntimeAutoConfiguration

--- a/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.jooq.test.autoconfigure.AutoConfigureJooq.imports
+++ b/spring-modulith-runtime/src/main/resources/META-INF/spring/org.springframework.boot.jooq.test.autoconfigure.AutoConfigureJooq.imports
@@ -1,0 +1,1 @@
+org.springframework.modulith.runtime.autoconfigure.SpringModulithRuntimeAutoConfiguration

--- a/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/autoconfigure/SpringModulithFlywayAutoConfigurationIntegrationTests.java
+++ b/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/autoconfigure/SpringModulithFlywayAutoConfigurationIntegrationTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.runtime.autoconfigure;
+
+import static org.assertj.core.api.Assertions.*;
+
+import example.SampleApplication;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.modulith.runtime.autoconfigure.SpringModulithRuntimeAutoConfiguration.SpringModulithFlywayAutoConfiguration;
+import org.springframework.modulith.runtime.test.DataJdbcSlicing;
+import org.springframework.modulith.runtime.test.DataJpaSlicing;
+import org.springframework.modulith.runtime.test.DataR2dbcSlicing;
+import org.springframework.modulith.runtime.test.JdbcSlicing;
+import org.springframework.modulith.runtime.test.JooqSlicing;
+
+/**
+ * Integration tests for
+ * {@link org.springframework.modulith.runtime.autoconfigure.SpringModulithRuntimeAutoConfiguration.SpringModulithFlywayAutoConfiguration}.
+ *
+ * @author Oliver Drotbohm
+ */
+class SpringModulithFlywayAutoConfigurationIntegrationTests {
+
+	@TestFactory // GH-1706
+	Stream<DynamicTest> activatesFlywayAutoConfigurationForSlices() {
+
+		var testTypes = Stream.of(DataJdbcSlicing.class,
+				DataJpaSlicing.class,
+				DataR2dbcSlicing.class,
+				JdbcSlicing.class,
+				JooqSlicing.class);
+
+		return DynamicTest.stream(testTypes,
+				it -> getTestAnnotationName(it) + " enables runtime auto-configuration",
+				it -> {
+
+					new ApplicationContextRunner()
+							.withUserConfiguration(SampleApplication.class)
+							.withUserConfiguration(it)
+							.run(ctxt -> {
+								assertThat(ctxt).hasSingleBean(SpringModulithFlywayAutoConfiguration.class);
+							});
+				});
+	}
+
+	private String getTestAnnotationName(Class<?> type) {
+
+		return Stream.of(type.getDeclaredAnnotations())
+				.map(Annotation::annotationType)
+				.map(Class::getSimpleName)
+				.filter(it -> it.endsWith("Test"))
+				.findFirst()
+				.orElseThrow(
+						() -> new IllegalArgumentException("No annotation ending in …Test found on %s!".formatted(type.getName())));
+	}
+}

--- a/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/DataJdbcSlicing.java
+++ b/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/DataJdbcSlicing.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.runtime.test;
+
+import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration
+@DataJdbcTest
+public class DataJdbcSlicing {}

--- a/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/DataJpaSlicing.java
+++ b/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/DataJpaSlicing.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.runtime.test;
+
+import static org.mockito.Mockito.*;
+
+import jakarta.persistence.EntityManagerFactory;
+
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+
+@TestConfiguration
+@DataJpaTest
+@TestPropertySource(properties = "spring.data.r2dbc.repositories.enabled=false")
+public class DataJpaSlicing {
+
+	@Bean
+	static EntityManagerFactory entityManagerFactory() {
+		return mock(EntityManagerFactory.class);
+	}
+}

--- a/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/DataR2dbcSlicing.java
+++ b/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/DataR2dbcSlicing.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.runtime.test;
+
+import org.springframework.boot.data.r2dbc.test.autoconfigure.DataR2dbcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration
+@DataR2dbcTest
+public class DataR2dbcSlicing {}

--- a/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/JdbcSlicing.java
+++ b/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/JdbcSlicing.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.runtime.test;
+
+import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration
+@JdbcTest
+public class JdbcSlicing {}

--- a/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/JooqSlicing.java
+++ b/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/test/JooqSlicing.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.runtime.test;
+
+import org.springframework.boot.jooq.test.autoconfigure.JooqTest;
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration
+@JooqTest
+public class JooqSlicing {}

--- a/spring-modulith-runtime/src/test/resources/application.properties
+++ b/spring-modulith-runtime/src/test/resources/application.properties
@@ -1,1 +1,2 @@
 spring.main.banner-mode=OFF
+spring.r2dbc.url=r2dbc:h2:mem://./testdb

--- a/src/docs/antora/.github/workflows/deploy-docs.yml
+++ b/src/docs/antora/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
     # if: github.repository_owner == 'spring-projects'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: docs-build
           fetch-depth: 1


### PR DESCRIPTION
## Summary
- Simplify the default `status` assignment in `JpaEventPublication`.
- Remove an unreachable `completionDate` check from the constructor.

## Details
`JpaEventPublication` previously initialized `status` with:

```java
this.status = status != null ? status : completionDate != null ? Status.COMPLETED : Status.PROCESSING;
```

However, completionDate is an instance field, not a constructor parameter. During constructor execution it still has its default value, null, so the Status.COMPLETED branch is not reachable from this expression.

This change keeps the effective behavior and makes the defaulting logic explicit:

```java
this.status = status != null ? status : Status.PROCESSING;
```