### PR TITLE
Require RabbitMQ publisher confirmation for outbox-based externalization

### DIFF
--- a/spring-modulith-events/spring-modulith-events-amqp/src/main/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-amqp/src/main/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfiguration.java
@@ -96,7 +96,7 @@ class RabbitEventExternalizerConfiguration {
 		class NamastackOutboxAutoConfiguration {
 
 			@Bean
-			OutboxHandler kafkaOutboxExternalizer() {
+			OutboxHandler namastackRabbitOutboxExternalizer() {
 
 				logger.debug("Registering Namastack domain event outbox externalization to RabbitMQ.");
 
@@ -109,7 +109,7 @@ class RabbitEventExternalizerConfiguration {
 		class JobRunrOutboxAutoConfiguration {
 
 			@Bean
-			JobRunrExternalizationTransport jobRunrOutboxExternalizer() {
+			JobRunrExternalizationTransport jobRunrRabbitOutboxExternalizer() {
 
 				logger.debug("Registering JobRunr domain event outbox externalization to RabbitMQ.");
 

--- a/spring-modulith-events/spring-modulith-events-amqp/src/main/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-amqp/src/main/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfiguration.java
@@ -17,13 +17,16 @@ package org.springframework.modulith.events.amqp;
 
 import io.namastack.outbox.handler.OutboxHandler;
 
+import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 
 import org.jobrunr.scheduling.JobScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitMessageOperations;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -31,6 +34,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.core.env.Environment;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.modulith.events.EventExternalizationConfiguration;
 import org.springframework.modulith.events.ExternalizationMode;
@@ -41,6 +45,7 @@ import org.springframework.modulith.events.support.EventExternalizationTransport
 import org.springframework.modulith.events.support.EventExternalizerModuleListener;
 import org.springframework.modulith.events.support.OutboxEventExternalizer;
 import org.springframework.modulith.events.support.OutboxEventExternalizerFactory;
+import org.springframework.util.Assert;
 
 /**
  * Auto-configuration to set up a {@link org.springframework.modulith.events.support.DelegatingEventExternalizer} to
@@ -58,6 +63,7 @@ import org.springframework.modulith.events.support.OutboxEventExternalizerFactor
 class RabbitEventExternalizerConfiguration {
 
 	private static final Logger logger = LoggerFactory.getLogger(RabbitEventExternalizerConfiguration.class);
+	private static final String PUBLISHER_CONFIRM_TYPE = "spring.rabbitmq.publisher-confirm-type";
 
 	@Bean
 	@ConditionalOnProperty(name = ExternalizationMode.PROPERTY, havingValue = "module-listener", matchIfMissing = true)
@@ -77,9 +83,12 @@ class RabbitEventExternalizerConfiguration {
 		private final OutboxEventExternalizer externalizer;
 
 		RabbitOutboxConfiguration(EventExternalizationConfiguration configuration, RabbitMessageOperations operations,
-				BeanFactory beanFactory, OutboxEventExternalizerFactory factory) {
+				BeanFactory beanFactory, OutboxEventExternalizerFactory factory, Environment environment) {
 
-			this.externalizer = factory.forTransport(createRabbitTransport(configuration, operations, beanFactory));
+			Assert.state("correlated".equalsIgnoreCase(environment.getProperty(PUBLISHER_CONFIRM_TYPE)),
+					() -> "RabbitMQ outbox event externalization requires " + PUBLISHER_CONFIRM_TYPE + "=correlated!");
+
+			this.externalizer = factory.forTransport(createConfirmingRabbitTransport(configuration, operations, beanFactory));
 		}
 
 		@AutoConfiguration
@@ -124,6 +133,34 @@ class RabbitEventExternalizerConfiguration {
 			operations.convertAndSend(routing.getTarget(payload), routing.getKey(payload), payload, headers);
 
 			return CompletableFuture.completedFuture(null);
+		};
+	}
+
+	private static EventExternalizationTransport createConfirmingRabbitTransport(
+			EventExternalizationConfiguration configuration, RabbitMessageOperations operations,
+			BeanFactory factory) {
+
+		var context = new StandardEvaluationContext();
+		context.setBeanResolver(new BeanFactoryResolver(factory));
+
+		return (payload, target) -> {
+
+			var routing = BrokerRouting.of(target, context);
+
+			var correlation = new CorrelationData();
+			var headers = new HashMap<>(configuration.getHeadersFor(payload));
+
+			headers.put(AmqpHeaders.PUBLISH_CONFIRM_CORRELATION, correlation);
+
+			operations.convertAndSend(routing.getTarget(payload), routing.getKey(payload), payload, headers);
+
+			return correlation.getFuture().thenAccept(confirm -> {
+
+				if (!confirm.ack()) {
+					throw new IllegalStateException("RabbitMQ publisher confirm was nacked: "
+							+ (confirm.reason() != null ? confirm.reason() : "no reason"));
+				}
+			});
 		};
 	}
 }

--- a/spring-modulith-events/spring-modulith-events-amqp/src/test/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfigurationIntegrationTests.java
+++ b/spring-modulith-events/spring-modulith-events-amqp/src/test/java/org/springframework/modulith/events/amqp/RabbitEventExternalizerConfigurationIntegrationTests.java
@@ -20,12 +20,20 @@ import static org.mockito.Mockito.*;
 
 import io.namastack.outbox.handler.OutboxHandler;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import org.jmolecules.event.annotation.Externalized;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitMessageOperations;
+import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -42,12 +50,36 @@ import org.springframework.modulith.test.PublishedEventsFactory;
  * Integration tests for {@link RabbitEventExternalizerConfiguration}.
  *
  * @author Oliver Drotbohm
+ * @author Roland Beisel
  * @since 1.1
  */
 class RabbitEventExternalizerConfigurationIntegrationTests {
 
 	static final EventExternalizationConfiguration EXTERNALIZATION_ENABLED = EventExternalizationConfiguration
 			.defaults("org").build();
+
+	@Test
+	void requiresCorrelatedPublisherConfirmsForOutboxMode() {
+
+		basicSetupWithoutPublisherConfirms(EXTERNALIZATION_ENABLED, confirmingOperations())
+				.withPropertyValues(ExternalizationMode.PROPERTY + "=" + ExternalizationMode.OUTBOX)
+				.run(ctxt -> {
+					assertThat(ctxt).hasFailed();
+					assertThat(ctxt.getStartupFailure())
+							.hasRootCauseMessage("RabbitMQ outbox event externalization requires "
+									+ "spring.rabbitmq.publisher-confirm-type=correlated!");
+				});
+	}
+
+	@Test
+	void doesNotRequireCorrelatedPublisherConfirmsForModuleListenerMode() {
+
+		basicSetupWithoutPublisherConfirms(EXTERNALIZATION_ENABLED, mock(RabbitMessageOperations.class))
+				.run(ctxt -> {
+					assertThat(ctxt).hasNotFailed();
+					assertThat(ctxt).hasSingleBean(EventExternalizerModuleListener.class);
+				});
+	}
 
 	@Test // GH-342
 	void registersExternalizerByDefault() {
@@ -120,11 +152,123 @@ class RabbitEventExternalizerConfigurationIntegrationTests {
 		assertEventExternalizedPublished(OutboxHandler.class, (transport, event) -> transport.handle(event, null));
 	}
 
+	@Test
+	void propagatesSynchronousFailureAsFailedFuture() {
+
+		var operations = mock(RabbitMessageOperations.class);
+		var failure = new IllegalStateException("Unable to publish!");
+
+		doThrow(failure).when(operations).convertAndSend(any(), any(), any(), anyMap());
+
+		basicSetup(EXTERNALIZATION_ENABLED, operations)
+				.run(ctxt -> {
+
+					var result = ctxt.getBean(EventExternalizerModuleListener.class).externalize(new SampleEvent());
+
+					assertThat(result).isCompletedExceptionally();
+					assertThatThrownBy(result::join).hasRootCause(failure);
+				});
+	}
+
+	@Test
+	void completesTransportFutureAfterPositivePublisherConfirm() {
+
+		var correlations = new ArrayList<CorrelationData>();
+		var sent = new CountDownLatch(1);
+		var operations = capturingOperations(correlations, sent);
+
+		basicSetup(EXTERNALIZATION_ENABLED, operations)
+				.withPropertyValues(ExternalizationMode.PROPERTY + "=" + ExternalizationMode.OUTBOX)
+				.run(ctxt -> {
+
+					var handler = ctxt.getBean(OutboxHandler.class);
+					var result = CompletableFuture.runAsync(() -> handler.handle(new SampleEvent(), null));
+
+					assertThat(sent.await(1, TimeUnit.SECONDS)).isTrue();
+					assertThat(result).isNotDone();
+
+					assertThat(correlations).singleElement()
+							.satisfies(it -> it.getFuture().complete(new CorrelationData.Confirm(true, null)));
+
+					assertThat(result).succeedsWithin(1, TimeUnit.SECONDS);
+				});
+	}
+
+	@Test
+	void completesTransportFutureExceptionallyAfterPublisherNack() {
+
+		assertPublisherNack(JobRunrExternalizationTransport.class, JobRunrExternalizationTransport::externalize);
+	}
+
+	@Test
+	void moduleListenerDoesNotUsePublisherConfirms() {
+
+		var operations = mock(RabbitMessageOperations.class);
+
+		doAnswer(invocation -> {
+
+			Map<String, Object> headers = invocation.getArgument(3);
+
+			assertThat(headers).doesNotContainKey(AmqpHeaders.PUBLISH_CONFIRM_CORRELATION);
+
+			return null;
+		}).when(operations).convertAndSend(any(), any(), any(), anyMap());
+
+		basicSetupWithoutPublisherConfirms(EXTERNALIZATION_ENABLED, operations)
+				.run(ctxt -> {
+
+					var result = ctxt.getBean(EventExternalizerModuleListener.class).externalize(new SampleEvent());
+
+					assertThat(result).isCompleted();
+				});
+	}
+
+	@Test
+	void addsUniquePublisherConfirmCorrelationForEachPublish() {
+
+		var correlations = new ArrayList<CorrelationData>();
+
+		basicSetup(EXTERNALIZATION_ENABLED, confirmingOperations(correlations))
+				.withPropertyValues(ExternalizationMode.PROPERTY + "=" + ExternalizationMode.OUTBOX)
+				.run(ctxt -> {
+
+					var handler = ctxt.getBean(OutboxHandler.class);
+
+					handler.handle(new SampleEvent(), null);
+					handler.handle(new SampleEvent(), null);
+
+					assertThat(correlations)
+							.hasSize(2)
+							.extracting(CorrelationData::getId)
+							.doesNotHaveDuplicates();
+				});
+	}
+
+	@Test
+	void propagatesPublisherNackToNamastackOutboxHandler() {
+
+		assertPublisherNack(OutboxHandler.class, (transport, event) -> transport.handle(event, null));
+	}
+
 	private ApplicationContextRunner basicSetup() {
 		return basicSetup(null);
 	}
 
 	private ApplicationContextRunner basicSetup(@Nullable EventExternalizationConfiguration configuration,
+			String... excluded) {
+
+		return basicSetup(configuration, confirmingOperations(), excluded);
+	}
+
+	private ApplicationContextRunner basicSetup(@Nullable EventExternalizationConfiguration configuration,
+			RabbitMessageOperations operations, String... excluded) {
+
+		return basicSetupWithoutPublisherConfirms(configuration, operations, excluded)
+				.withPropertyValues("spring.rabbitmq.publisher-confirm-type=correlated");
+	}
+
+	private ApplicationContextRunner basicSetupWithoutPublisherConfirms(
+			@Nullable EventExternalizationConfiguration configuration, RabbitMessageOperations operations,
 			String... excluded) {
 
 		var defaulted = configuration == null ? EventExternalizationConfiguration.disabled() : configuration;
@@ -134,7 +278,7 @@ class RabbitEventExternalizerConfigurationIntegrationTests {
 						RabbitEventExternalizerConfiguration.class,
 						EventExternalizationAutoConfiguration.class))
 				.withBean(EventExternalizationConfiguration.class, () -> defaulted)
-				.withBean(RabbitMessageOperations.class, () -> mock(RabbitMessageOperations.class));
+				.withBean(RabbitMessageOperations.class, () -> operations);
 
 		if (excluded.length > 0) {
 			runner = runner.withClassLoader(new FilteredClassLoader(excluded));
@@ -160,6 +304,66 @@ class RabbitEventExternalizerConfigurationIntegrationTests {
 					assertThat(events.ofType(EventExternalized.class)
 							.matching(it -> it.getEvent().equals(event))).hasSize(1);
 				});
+	}
+
+	private static RabbitMessageOperations confirmingOperations() {
+		return confirmingOperations(new ArrayList<>());
+	}
+
+	private static RabbitMessageOperations confirmingOperations(List<CorrelationData> correlations) {
+
+		var operations = mock(RabbitMessageOperations.class);
+
+		doAnswer(invocation -> {
+
+			Map<String, Object> headers = invocation.getArgument(3);
+			var correlation = (CorrelationData) headers.get(AmqpHeaders.PUBLISH_CONFIRM_CORRELATION);
+
+			correlations.add(correlation);
+			correlation.getFuture().complete(new CorrelationData.Confirm(true, null));
+
+			return null;
+		}).when(operations).convertAndSend(any(), any(), any(), anyMap());
+
+		return operations;
+	}
+
+	private static RabbitMessageOperations capturingOperations(List<CorrelationData> correlations, CountDownLatch sent) {
+
+		var operations = mock(RabbitMessageOperations.class);
+
+		doAnswer(invocation -> {
+
+			Map<String, Object> headers = invocation.getArgument(3);
+
+			assertThat(headers).containsKey(AmqpHeaders.PUBLISH_CONFIRM_CORRELATION);
+			correlations.add((CorrelationData) headers.get(AmqpHeaders.PUBLISH_CONFIRM_CORRELATION));
+			sent.countDown();
+
+			return null;
+		}).when(operations).convertAndSend(any(), any(), any(), anyMap());
+
+		return operations;
+	}
+
+	private <T> void assertPublisherNack(Class<T> transportType, BiConsumer<T, Object> consumer) {
+
+		var operations = mock(RabbitMessageOperations.class);
+
+		doAnswer(invocation -> {
+
+			Map<String, Object> headers = invocation.getArgument(3);
+			var correlation = (CorrelationData) headers.get(AmqpHeaders.PUBLISH_CONFIRM_CORRELATION);
+
+			correlation.getFuture().complete(new CorrelationData.Confirm(false, "rejected"));
+
+			return null;
+		}).when(operations).convertAndSend(any(), any(), any(), anyMap());
+
+		basicSetup(EXTERNALIZATION_ENABLED, operations)
+				.withPropertyValues(ExternalizationMode.PROPERTY + "=" + ExternalizationMode.OUTBOX)
+				.run(ctxt -> assertThatThrownBy(() -> consumer.accept(ctxt.getBean(transportType), new SampleEvent()))
+						.hasRootCauseMessage("RabbitMQ publisher confirm was nacked: rejected"));
 	}
 
 	@Externalized

--- a/spring-modulith-events/spring-modulith-events-messaging/src/main/java/org/springframework/modulith/events/messaging/SpringMessagingEventExternalizerConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-messaging/src/main/java/org/springframework/modulith/events/messaging/SpringMessagingEventExternalizerConfiguration.java
@@ -87,7 +87,7 @@ class SpringMessagingEventExternalizerConfiguration {
 		class NamastackOutboxAutoConfiguration {
 
 			@Bean
-			OutboxHandler namastackKafkaOutboxExternalizer() {
+			OutboxHandler namastackSpringMessagingOutboxExternalizer() {
 
 				logger.debug("Registering Namastack domain event outbox externalization for Spring Messaging.");
 
@@ -100,7 +100,7 @@ class SpringMessagingEventExternalizerConfiguration {
 		class JobRunrOutboxAutoConfiguration {
 
 			@Bean
-			JobRunrExternalizationTransport jobRunrKafkaOutboxExternalizer() {
+			JobRunrExternalizationTransport jobRunrSpringMessagingOutboxExternalizer() {
 
 				logger.debug("Registering JobRunr domain event outbox externalization for Spring Messaging.");
 

--- a/src/docs/antora/modules/ROOT/pages/events.adoc
+++ b/src/docs/antora/modules/ROOT/pages/events.adoc
@@ -437,14 +437,6 @@ The logical routing key will be used as Kafka's topic and message key.
 |Uses Spring AMQP for the interaction with any compatible broker.
 Requires an explicit dependency declaration for Spring Rabbit for example.
 The logical routing key will be used as AMQP routing key.
-RabbitMQ outbox usage requires correlated publisher confirms to be enabled through
-`spring.rabbitmq.publisher-confirm-type=correlated`, while the default module-listener mode does not.
-While `convertAndSend(…)` detects synchronous connection, authentication, channel creation, and publishing failures,
-it does not independently guarantee that RabbitMQ accepted a particular publish.
-Spring Modulith therefore only considers RabbitMQ outbox externalization successful after receiving a positive
-publisher confirm.
-This guarantee does not cover consumer processing or unroutable messages; publisher returns and mandatory publishing
-are not handled by the integration.
 
 |JMS
 |`spring-modulith-events-jms`

--- a/src/docs/antora/modules/ROOT/pages/events.adoc
+++ b/src/docs/antora/modules/ROOT/pages/events.adoc
@@ -437,6 +437,14 @@ The logical routing key will be used as Kafka's topic and message key.
 |Uses Spring AMQP for the interaction with any compatible broker.
 Requires an explicit dependency declaration for Spring Rabbit for example.
 The logical routing key will be used as AMQP routing key.
+RabbitMQ outbox usage requires correlated publisher confirms to be enabled through
+`spring.rabbitmq.publisher-confirm-type=correlated`, while the default module-listener mode does not.
+While `convertAndSend(…)` detects synchronous connection, authentication, channel creation, and publishing failures,
+it does not independently guarantee that RabbitMQ accepted a particular publish.
+Spring Modulith therefore only considers RabbitMQ outbox externalization successful after receiving a positive
+publisher confirm.
+This guarantee does not cover consumer processing or unroutable messages; publisher returns and mandatory publishing
+are not handled by the integration.
 
 |JMS
 |`spring-modulith-events-jms`


### PR DESCRIPTION
# Require RabbitMQ Publisher Confirms for Event Externalization

## Summary

RabbitMQ outbox event externalization previously considered a publish successful as soon as
`RabbitMessageOperations.convertAndSend(…)` returned.

That call reports failures which can be detected synchronously, including failures to establish a broker connection,
authentication failures, connection or channel creation failures, and synchronous I/O failures during publishing.
However, a successful return does not confirm that RabbitMQ accepted the individual publish. For example, the
connection can fail immediately after the local write, or the broker can asynchronously reject the publish.

This change requires correlated RabbitMQ publisher confirms for outbox mode. RabbitMQ outbox externalization is now
only considered successful after a positive publisher confirm.

The default module-listener mode remains unchanged and does not require publisher confirms.

## Changes

- Require the following configuration when RabbitMQ is used in outbox mode:

  ```properties
  spring.rabbitmq.publisher-confirm-type=correlated
  ```

- Fail application startup with a clear error when correlated publisher confirms are missing in RabbitMQ outbox mode.
- Create a unique `CorrelationData` instance for every RabbitMQ outbox publish.
- Pass the correlation data through `AmqpHeaders.PUBLISH_CONFIRM_CORRELATION`.
- Complete the outbox transport future only after receiving a positive publisher confirm.
- Complete the transport future exceptionally after receiving a publisher nack.
- Continue propagating synchronous failures from `convertAndSend(…)` as failed transport futures.
- Keep module-listener publishing fire-and-forget and independent of publisher-confirm configuration.
- Document the RabbitMQ outbox configuration requirement and delivery guarantee.
- Correct copied Kafka bean names in the RabbitMQ and Spring Messaging outbox configurations.

## Failure Scenarios

### Included

The following scenarios prevent RabbitMQ outbox externalization from being considered successful:

- The broker connection cannot be established.
- Authentication fails.
- Connection or channel creation fails.
- `basicPublish(…)` encounters a synchronous I/O failure.
- `convertAndSend(…)` otherwise fails synchronously.
- RabbitMQ negatively acknowledges the publish with a publisher nack.
- No positive publisher confirm has been received yet.

Synchronous failures are propagated through the transport's failed `CompletableFuture`. Publisher nacks also complete
the future exceptionally. Blocking outbox integrations receive those failures through `externalizeBlocking(…)`, while
asynchronous callers can observe the returned future.

### Not Included

This change intentionally does not cover:

- Unroutable messages. RabbitMQ can positively confirm a publish even when no queue receives it.
- Publisher returns.
- Mandatory publishing.
- Consumer processing, acknowledgements, or failures.
- End-to-end delivery to, or processing by, a consumer.
- An arbitrary publisher-confirm timeout.

Publisher returns and mandatory publishing are separate concerns from confirming that RabbitMQ accepted a publish and
remain outside the scope of this change.

## Tests

Added or updated tests verify that:

- Missing correlated publisher confirms fail startup in outbox mode with a clear error.
- Module-listener mode starts without correlated publisher confirms.
- Module-listener publishing does not add publisher-confirm correlation data.
- Synchronous `convertAndSend(…)` failures produce failed transport futures.
- A positive publisher confirm completes outbox externalization successfully.
- A publisher nack completes outbox externalization exceptionally.
- Publisher nacks propagate through the JobRunr and Namastack outbox handlers.
- Every outbox publish receives a unique correlation ID.
- `CorrelationData` is passed through `AmqpHeaders.PUBLISH_CONFIRM_CORRELATION`.

## Verification

- Focused RabbitMQ externalizer configuration tests: 16 tests passed.
- Full AMQP test suite: 17 tests passed, including module-listener publishing without publisher confirms.
- Events core and Namastack integration tests passed.
- AMQP reactor build verification passed.
