### PR TITLE
GH-1733 - Use container-backed MongoClient in MongoDB tests.

### DIFF
--- a/spring-modulith-events/spring-modulith-events-mongodb/src/test/java/org/springframework/modulith/testapp/Infrastructure.java
+++ b/spring-modulith-events/spring-modulith-events-mongodb/src/test/java/org/springframework/modulith/testapp/Infrastructure.java
@@ -19,14 +19,16 @@ import org.bson.UuidRepresentation;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 import org.testcontainers.mongodb.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import com.mongodb.MongoClientSettings.Builder;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 
 @TestConfiguration(proxyBeanMethods = false)
-public class Infrastructure extends AbstractMongoClientConfiguration {
+public class Infrastructure {
 
 	@Bean
 	@ServiceConnection
@@ -34,21 +36,14 @@ public class Infrastructure extends AbstractMongoClientConfiguration {
 		return new MongoDBContainer(DockerImageName.parse("mongo:latest"));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.config.MongoConfigurationSupport#getDatabaseName()
-	 */
-	@Override
-	protected String getDatabaseName() {
-		return "test";
-	}
+	@Bean
+	MongoClient mongoClient(MongoDBContainer container) {
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.mongodb.config.MongoConfigurationSupport#configureClientSettings(com.mongodb.MongoClientSettings.Builder)
-	 */
-	@Override
-	protected void configureClientSettings(Builder builder) {
-		builder.uuidRepresentation(UuidRepresentation.STANDARD);
+		var settings = MongoClientSettings.builder()
+				.uuidRepresentation(UuidRepresentation.STANDARD)
+				.applyConnectionString(new ConnectionString(container.getReplicaSetUrl()))
+				.build();
+
+		return MongoClients.create(settings);
 	}
 }


### PR DESCRIPTION
Fixes #1733.

### Problem

The MongoDB event publication tests declare a `MongoDBContainer` with `@ServiceConnection`, but the test infrastructure also extends `AbstractMongoClientConfiguration`.

That inherited configuration path creates the `MongoClient` from Spring Data MongoDB defaults, so the tests can attempt to connect to `127.0.0.1:27017` instead of the dynamically mapped Testcontainers port. This makes the tests fail in CI when no MongoDB instance is available on the default localhost port.

### Solution

This PR provides an explicit `MongoClient` bean backed by `MongoDBContainer#getReplicaSetUrl()` and keeps the existing `UuidRepresentation.STANDARD` setting.

### Verification

- `git diff --check`
- `JAVA_HOME=<JDK 17> ./mvnw -pl spring-modulith-events/spring-modulith-events-mongodb test`

Result:

```text
Tests run: 56, Failures: 0, Errors: 0, Skipped: 0
```
