### PR TITLE
GH-1748 - Guard against unresolvable generics in observed method rendering

### DIFF
--- a/spring-modulith-observability/spring-modulith-observability-core/src/main/java/org/springframework/modulith/observability/support/DefaultObservedModule.java
+++ b/spring-modulith-observability/spring-modulith-observability-core/src/main/java/org/springframework/modulith/observability/support/DefaultObservedModule.java
@@ -126,7 +126,14 @@ class DefaultObservedModule implements ObservedModule {
 
 	private String render(ResolvableType type) {
 
-		String formatted = FormattableType.of(type.resolve()).getAbbreviatedFullName(module,
+		var resolved = type.resolve();
+
+		// Unbounded wildcards (Foo<?>) and unbounded type variables (Foo<T>) resolve to null
+		if (resolved == null) {
+			return "?";
+		}
+
+		String formatted = FormattableType.of(resolved).getAbbreviatedFullName(module,
 				NonModuleTypeAbbreviation.ABBREVIATED);
 
 		if (!type.hasGenerics()) {

--- a/spring-modulith-observability/spring-modulith-observability-core/src/test/java/example/sample/SampleComponent.java
+++ b/spring-modulith-observability/spring-modulith-observability-core/src/test/java/example/sample/SampleComponent.java
@@ -15,6 +15,8 @@
  */
 package example.sample;
 
+import java.util.List;
+
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
@@ -26,4 +28,8 @@ public class SampleComponent {
 
 	@Async
 	public void someMethod() {}
+
+	public void withWildcard(List<?> items) {}
+
+	public <T> void withTypeVariable(List<T> items) {}
 }

--- a/spring-modulith-observability/spring-modulith-observability-core/src/test/java/org/springframework/modulith/observability/support/DefaultObservedModuleUnitTests.java
+++ b/spring-modulith-observability/spring-modulith-observability-core/src/test/java/org/springframework/modulith/observability/support/DefaultObservedModuleUnitTests.java
@@ -18,9 +18,11 @@ package org.springframework.modulith.observability.support;
 import static org.assertj.core.api.Assertions.*;
 
 import example.sample.ObservedComponent;
+import example.sample.SampleComponent;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
+import java.util.List;
 
 import org.aopalliance.intercept.MethodInvocation;
 import org.junit.jupiter.api.Test;
@@ -51,9 +53,39 @@ class DefaultObservedModuleUnitTests {
 		assertThat(observedModule.isEventListenerInvocation(forMethod("someMethod"))).isFalse();
 	}
 
+	@Test // GH-1748
+	void rendersUnboundedWildcardGenericWithoutException() throws Exception {
+
+		var invocation = forMethod(new SampleComponent(), "withWildcard", List.class);
+
+		assertThatNoException().isThrownBy(() -> observedModule.format(invocation));
+		assertThat(observedModule.format(invocation)).contains("withWildcard(").contains("<?>");
+	}
+
+	@Test // GH-1748
+	void rendersUnboundedTypeVariableGenericWithoutException() throws Exception {
+
+		var invocation = forMethod(new SampleComponent(), "withTypeVariable", List.class);
+
+		assertThatNoException().isThrownBy(() -> observedModule.format(invocation));
+		assertThat(observedModule.format(invocation)).contains("withTypeVariable(").contains("<?>");
+	}
+
 	private static MethodInvocation forMethod(String name, Class<?>... parameterTypes) throws Exception {
 
 		var method = ObservedComponent.class.getDeclaredMethod(name, parameterTypes);
+
+		return forMethod(null, method);
+	}
+
+	private static MethodInvocation forMethod(Object target, String name, Class<?>... parameterTypes) throws Exception {
+
+		var method = target.getClass().getDeclaredMethod(name, parameterTypes);
+
+		return forMethod(target, method);
+	}
+
+	private static MethodInvocation forMethod(Object target, Method method) {
 
 		return new MethodInvocation() {
 
@@ -64,7 +96,7 @@ class DefaultObservedModuleUnitTests {
 
 			@Override
 			public Object getThis() {
-				return null;
+				return target;
 			}
 
 			@Override


### PR DESCRIPTION
## Summary

Fixes #1748.

When observability is enabled, invoking an observed module service method whose parameter has an **unbounded wildcard** generic (`Foo<?>`) — or an unbounded type variable (`Foo<T>`) — failed with a `NullPointerException` while rendering the observed method signature.

This is a sibling of #1713. `DefaultObservedModule.render(ResolvableType)` passed the result of `ResolvableType.resolve()` straight into `FormattableType.of(Class)` without a null check. For an unbounded wildcard/type variable, `resolve()` returns `null`, so `FormattableType.of` threw an NPE dereferencing `type.getTypeName()`.

Because `ModuleEntryInterceptor.invoke` evaluates `module.format(invocation)` **before** `invocation.proceed()`, the exception aborted the call entirely — the target method was never invoked.

## Fix

`render(ResolvableType)` now falls back to rendering `?` when the type resolves to `null`.

## Tests

Added two regression tests in `DefaultObservedModuleUnitTests` (wildcard and type-variable parameters) that exercise `format()` and assert no exception is thrown and the rendered signature contains `<?>`. Backed by new fixture methods on `SampleComponent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)