### PR TITLE
GH-1750 - Always execute __root module migrations during test runs

### DIFF
--- a/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/flyway/ActiveModules.java
+++ b/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/flyway/ActiveModules.java
@@ -59,6 +59,10 @@ public class ActiveModules implements MigrationFilter {
 			return true;
 		}
 
+		if (SpringModulithFlywayMigrationStrategy.ROOT.equals(identifier)) {
+			return true;
+		}
+
 		var execution = factory.getBeanProvider(ModuleTestExecution.class).getIfAvailable();
 
 		return execution != null ? execution.isIncludedInExecution(identifier) : true;

--- a/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/flyway/SpringModulithFlywayMigrationStrategy.java
+++ b/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/flyway/SpringModulithFlywayMigrationStrategy.java
@@ -38,7 +38,7 @@ import org.springframework.util.Assert;
  */
 public class SpringModulithFlywayMigrationStrategy implements FlywayMigrationStrategy {
 
-	private static final ApplicationModuleIdentifier ROOT = ApplicationModuleIdentifier.of("__root");
+	static final ApplicationModuleIdentifier ROOT = ApplicationModuleIdentifier.of("__root");
 	private static final Logger LOGGER = LoggerFactory.getLogger(SpringModulithFlywayMigrationStrategy.class);
 
 	private final ApplicationModuleIdentifiers identifiers;

--- a/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/flyway/ActiveModulesUnitTests.java
+++ b/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/flyway/ActiveModulesUnitTests.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.runtime.flyway;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.modulith.core.ApplicationModuleIdentifier;
+import org.springframework.modulith.test.ModuleTestExecution;
+
+/**
+ * Unit tests for {@link ActiveModules}.
+ *
+ * @author Seonwoo Jung
+ */
+@ExtendWith(MockitoExtension.class)
+class ActiveModulesUnitTests {
+
+	@Mock BeanFactory beanFactory;
+	@Mock Flyway flyway;
+	@Mock ModuleTestExecution execution;
+	@Mock ObjectProvider<ModuleTestExecution> provider;
+
+	@Test // GH-1750
+	void migratesRootModuleWithoutConsultingTestExecution() {
+
+		var filter = new ActiveModules(beanFactory);
+
+		assertThat(filter.shouldMigrate(SpringModulithFlywayMigrationStrategy.ROOT, flyway)).isTrue();
+		verifyNoInteractions(beanFactory);
+	}
+
+	@Test // GH-1750
+	void delegatesToTestExecutionForNonRootModules() {
+
+		var moduleIdentifier = ApplicationModuleIdentifier.of("order");
+
+		when(beanFactory.getBeanProvider(ModuleTestExecution.class)).thenReturn(provider);
+		when(provider.getIfAvailable()).thenReturn(execution);
+		when(execution.isIncludedInExecution(moduleIdentifier)).thenReturn(true);
+
+		var filter = new ActiveModules(beanFactory);
+
+		assertThat(filter.shouldMigrate(moduleIdentifier, flyway)).isTrue();
+		verify(execution).isIncludedInExecution(moduleIdentifier);
+	}
+
+	@Test // GH-1750
+	void skipsModuleNotIncludedInTestExecution() {
+
+		var moduleIdentifier = ApplicationModuleIdentifier.of("inventory");
+
+		when(beanFactory.getBeanProvider(ModuleTestExecution.class)).thenReturn(provider);
+		when(provider.getIfAvailable()).thenReturn(execution);
+		when(execution.isIncludedInExecution(moduleIdentifier)).thenReturn(false);
+
+		var filter = new ActiveModules(beanFactory);
+
+		assertThat(filter.shouldMigrate(moduleIdentifier, flyway)).isFalse();
+	}
+
+	@Test // GH-1750
+	void migratesAllModulesWhenNoTestExecutionAvailable() {
+
+		when(beanFactory.getBeanProvider(ModuleTestExecution.class)).thenReturn(provider);
+		when(provider.getIfAvailable()).thenReturn(null);
+
+		var filter = new ActiveModules(beanFactory);
+
+		assertThat(filter.shouldMigrate(ApplicationModuleIdentifier.of("order"), flyway)).isTrue();
+		assertThat(filter.shouldMigrate(SpringModulithFlywayMigrationStrategy.ROOT, flyway)).isTrue();
+	}
+}


### PR DESCRIPTION
Fixes #1750.

## Root cause

`org.springframework.modulith.runtime.flyway.ActiveModules` is the `MigrationFilter` that runs during module-sliced tests. It delegates to `ModuleTestExecution#isIncludedInExecution(identifier)` for every Flyway migration, including the synthetic `__root` module that `SpringModulithFlywayMigrationStrategy` always prepends to the identifier stream.

`ModuleTestExecution.includedModules` is composed of:

* the module under test,
* its declared dependencies,
* `@ApplicationModuleTest(extraIncludes = ...)`,
* shared modules.

`__root` is not an `ApplicationModule` in user code — it is a framework-level identifier carrying the cross-cutting Spring Modulith migrations (e.g. the `event_publication` table for the Event Publication Registry). It is therefore never present in `includedModules`, so `isIncludedInExecution(__root)` returns `false` and the `__root/V*__*.sql` scripts are silently dropped during tests.

Production startup is not affected because `ActiveModules` short-circuits to `true` when `org.springframework.modulith.test.ModuleTestExecution` is absent from the classpath — which matches the reporter's observation that the same `db/migration/__root` scripts are applied in production but not in slice tests.

## Change

Treat the `__root` identifier as always migrating in `ActiveModules#shouldMigrate(...)`. The constant on `SpringModulithFlywayMigrationStrategy.ROOT` is promoted from `private` to package-private so both classes in the `flyway` package can share the single source of truth for the identifier value.

## Tests

A new `ActiveModulesUnitTests` covers four invariants:

* `__root` always migrates and the `ModuleTestExecution` lookup is bypassed entirely.
* Non-root identifiers delegate to `ModuleTestExecution#isIncludedInExecution`.
* Non-root identifiers not included in the test execution are skipped.
* When no `ModuleTestExecution` bean is available, every identifier migrates.

`./mvnw -pl spring-modulith-runtime test` passes (28/28 tests in the `spring-modulith-runtime` module, including the new four and the existing `SpringModulithFlywayCustomizerUnitTests` and `SpringModulithFlywayAutoConfigurationIntegrationTests`).