### PR TITLE
Fix typo in staleness check-interval property

### DIFF
--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/StalenessMonitorConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/StalenessMonitorConfiguration.java
@@ -64,10 +64,10 @@ class StalenessMonitorConfiguration implements SchedulingConfigurer {
 		if (staleness.monitorStaleness()) {
 
 			LOGGER.info("Checking for stale event publications every {}.",
-					EventUtils.prettyPrint(staleness.getCheckIntervall()));
+					EventUtils.prettyPrint(staleness.getCheckInterval()));
 
 			taskRegistrar.addFixedDelayTask(() -> registry.markStalePublicationsFailed(staleness),
-					staleness.getCheckIntervall());
+					staleness.getCheckInterval());
 		}
 	}
 }

--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/StalenessProperties.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/config/StalenessProperties.java
@@ -34,7 +34,7 @@ import org.springframework.util.Assert;
 public class StalenessProperties implements Staleness {
 
 	public static StalenessProperties DEFAULTS = new StalenessProperties(null, null, null,
-			null, null);
+			null, null, null);
 
 	/**
 	 * Configures after which {@link Duration} an {@link org.springframework.modulith.events.EventPublication} marked as
@@ -57,7 +57,7 @@ public class StalenessProperties implements Staleness {
 	/**
 	 * Configures the {@link Duration} to check for stale event publications. Defaults to one minute.
 	 */
-	private final Duration checkIntervall;
+	private final Duration checkInterval;
 
 	@ConstructorBinding
 	StalenessProperties(
@@ -65,12 +65,15 @@ public class StalenessProperties implements Staleness {
 			@Nullable Duration processing,
 			@Nullable Duration resubmitted,
 			@Nullable Duration resubmission,
+			@Nullable Duration checkInterval,
 			@Nullable Duration checkIntervall) {
 
 		this.published = published == null ? Duration.ZERO : published;
 		this.processing = processing == null ? Duration.ZERO : processing;
 		this.resubmitted = resubmitted == null ? resubmission == null ? Duration.ZERO : resubmission : resubmitted;
-		this.checkIntervall = checkIntervall == null ? Duration.ofMinutes(1) : checkIntervall;
+		// Prefer check-interval; keep check-intervall as a deprecated alias for compatibility.
+		this.checkInterval = checkInterval != null ? checkInterval
+				: checkIntervall != null ? checkIntervall : Duration.ofMinutes(1);
 	}
 
 	boolean monitorStaleness() {
@@ -80,8 +83,8 @@ public class StalenessProperties implements Staleness {
 				|| !resubmitted.equals(Duration.ZERO);
 	}
 
-	Duration getCheckIntervall() {
-		return checkIntervall;
+	Duration getCheckInterval() {
+		return checkInterval;
 	}
 
 	/*

--- a/spring-modulith-events/spring-modulith-events-core/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -19,9 +19,9 @@
 			"description": "Whether to republish outstanding event publications on restarts of the application.",
 			"defaultValue": "false",
 			"deprecation": {
-				"replacement": "spring.modulith.events.republish-outstanding-events-on-restart", 
+				"replacement": "spring.modulith.events.republish-outstanding-events-on-restart",
 				"reason": "Moved to spring.modulith.events namespace. To be removed in 1.4.",
-				"since" : "1.3"
+				"since": "1.3"
 			}
 		},
 		{
@@ -54,10 +54,21 @@
 			"defaultValue": "false"
 		},
 		{
-			"name": "spring.modulith.events.staleness.check-intervall",
+			"name": "spring.modulith.events.staleness.check-interval",
 			"type": "java.time.Duration",
 			"description": "Configures the {@link Duration} to check for stale event publications. Defaults to one minute.",
 			"sourceType": "org.springframework.modulith.events.config.StalenessProperties"
+		},
+		{
+			"name": "spring.modulith.events.staleness.check-intervall",
+			"type": "java.time.Duration",
+			"description": "Configures the {@link Duration} to check for stale event publications. Defaults to one minute.",
+			"sourceType": "org.springframework.modulith.events.config.StalenessProperties",
+			"deprecation": {
+				"replacement": "spring.modulith.events.staleness.check-interval",
+				"reason": "Corrected spelling. To be removed in 2.2.",
+				"since": "2.1"
+			}
 		},
 		{
 			"name": "spring.modulith.events.staleness.processing",
@@ -83,9 +94,9 @@
 			"description": "Configures after which {@link Duration} an {@link org.springframework.modulith.events.EventPublication} marked as {@value org.springframework.modulith.events.EventPublication.Status#RESUBMITTED} will be considered stale.",
 			"sourceType": "org.springframework.modulith.events.config.StalenessProperties",
 			"deprecation": {
-				"replacement": "spring.modulith.events.staleness.resubmitted", 
+				"replacement": "spring.modulith.events.staleness.resubmitted",
 				"reason": "To align with the publication state. To be removed in 2.2.",
-				"since" : "2.1"
+				"since": "2.1"
 			}
 		}
 	]

--- a/spring-modulith-events/spring-modulith-events-core/src/test/java/org/springframework/modulith/events/config/EventPublicationAutoConfigurationIntegrationTests.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/test/java/org/springframework/modulith/events/config/EventPublicationAutoConfigurationIntegrationTests.java
@@ -142,7 +142,7 @@ class EventPublicationAutoConfigurationIntegrationTests {
 	void registersStalenessMonitorIfPropertiesConfigured() {
 
 		basicSetup()
-				.withPropertyValues("spring.modulith.events.staleness-check-intervall=10s")
+				.withPropertyValues("spring.modulith.events.staleness.check-interval=10s")
 				.run(context -> {
 					assertThat(context).hasSingleBean(SchedulingConfigurer.class);
 				});


### PR DESCRIPTION
## Summary
Fixes the misspelled `spring.modulith.events.staleness.check-intervall` property so it matches the documented `check-interval` name (and the appendix docs).

The Java field and getter are renamed accordingly. The old `check-intervall` name is kept as a deprecated alias for compatibility.

Fixes #1757

## Test plan
- [x] `./mvnw -pl spring-modulith-events/spring-modulith-events-core -am test -Dtest=EventPublicationAutoConfigurationIntegrationTests -Dsurefire.failIfNoSpecifiedTests=false`
- [ ] Confirm IDE metadata shows `check-interval` and marks `check-intervall` deprecated