### PR TITLE
GH-1774 | Modernize auto-configuration registration.

### DIFF
--- a/spring-modulith-events/spring-modulith-events-jdbc/src/main/java/org/springframework/modulith/events/jdbc/JdbcEventPublicationAutoConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-jdbc/src/main/java/org/springframework/modulith/events/jdbc/JdbcEventPublicationAutoConfiguration.java
@@ -21,11 +21,9 @@ import javax.sql.DataSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ProxyType;
 import org.springframework.context.annotation.Proxyable;
 import org.springframework.core.env.Environment;
@@ -44,8 +42,7 @@ import org.springframework.modulith.events.support.CompletionMode;
  * @author Oliver Drotbohm
  * @author Raed Ben Hamouda
  */
-@Configuration(proxyBeanMethods = false)
-@AutoConfigureBefore(EventPublicationAutoConfiguration.class)
+@AutoConfiguration(before = EventPublicationAutoConfiguration.class)
 @EnableConfigurationProperties(JdbcConfigurationProperties.class)
 class JdbcEventPublicationAutoConfiguration implements EventPublicationConfigurationExtension {
 

--- a/spring-modulith-events/spring-modulith-events-jpa/src/main/resources/META-INF/spring.factories
+++ b/spring-modulith-events/spring-modulith-events-jpa/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,2 @@
 org.springframework.modulith.events.config.EventPublicationConfigurationExtension=\
   org.springframework.modulith.events.jpa.JpaEventPublicationConfiguration
-
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.springframework.modulith.events.jpa.JpaEventPublicationAutoConfiguration,\
-  org.springframework.modulith.events.jpa.JpaEventPublicationConfiguration

--- a/spring-modulith-moments/src/main/java/org/springframework/modulith/moments/autoconfigure/MomentsAutoConfiguration.java
+++ b/spring-modulith-moments/src/main/java/org/springframework/modulith/moments/autoconfigure/MomentsAutoConfiguration.java
@@ -18,11 +18,11 @@ package org.springframework.modulith.moments.autoconfigure;
 import java.time.Clock;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.modulith.moments.support.Moments;
 import org.springframework.modulith.moments.support.MomentsProperties;
 import org.springframework.modulith.moments.support.TimeMachine;
@@ -36,7 +36,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableConfigurationProperties(MomentsProperties.class)
 @ConditionalOnProperty(name = "spring.modulith.moments.enabled", havingValue = "true", matchIfMissing = true)
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 class MomentsAutoConfiguration {
 
 	@Bean

--- a/spring-modulith-moments/src/main/resources/META-INF/spring.factories
+++ b/spring-modulith-moments/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.springframework.modulith.moments.autoconfigure.MomentsAutoConfiguration

--- a/spring-modulith-observability/spring-modulith-observability-core/src/main/java/org/springframework/modulith/observability/autoconfigure/ModuleObservabilityAutoConfiguration.java
+++ b/spring-modulith-observability/spring-modulith-observability-core/src/main/java/org/springframework/modulith/observability/autoconfigure/ModuleObservabilityAutoConfiguration.java
@@ -23,13 +23,13 @@ import java.util.function.Supplier;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnThreading;
 import org.springframework.boot.task.SimpleAsyncTaskExecutorCustomizer;
 import org.springframework.boot.task.ThreadPoolTaskExecutorCustomizer;
 import org.springframework.boot.thread.Threading;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
 import org.springframework.modulith.observability.ModulithEventMetricsCustomizer;
@@ -44,7 +44,7 @@ import org.springframework.modulith.runtime.ApplicationModulesRuntime;
 /**
  * @author Oliver Drotbohm
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnProperty(name = "management.tracing.enabled", havingValue = "true", matchIfMissing = true)
 class ModuleObservabilityAutoConfiguration {
 

--- a/spring-modulith-observability/spring-modulith-observability-core/src/main/java/org/springframework/modulith/observability/autoconfigure/SpringDataRestModuleObservabilityAutoConfiguration.java
+++ b/spring-modulith-observability/spring-modulith-observability-core/src/main/java/org/springframework/modulith/observability/autoconfigure/SpringDataRestModuleObservabilityAutoConfiguration.java
@@ -20,9 +20,9 @@ import io.micrometer.observation.ObservationRegistry;
 import java.util.function.Supplier;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.data.rest.webmvc.RepositoryController;
 import org.springframework.modulith.observability.ModulithObservationConvention;
@@ -33,7 +33,7 @@ import org.springframework.modulith.runtime.ApplicationModulesRuntime;
 /**
  * @author Oliver Drotbohm
  */
-@Configuration(proxyBeanMethods = false)
+@AutoConfiguration
 @ConditionalOnClass(RepositoryController.class)
 class SpringDataRestModuleObservabilityAutoConfiguration {
 


### PR DESCRIPTION
Closes #1774.

- Remove the dead `EnableAutoConfiguration` entries from `spring.factories` in `spring-modulith-moments` (file deleted) and `spring-modulith-events-jpa`. The `EventPublicationConfigurationExtension` entry in the latter is kept, as it is still consumed by the `EnablePersistentDomainEvents` import selector.
- Switch `MomentsAutoConfiguration`, `ModuleObservabilityAutoConfiguration`, `SpringDataRestModuleObservabilityAutoConfiguration`, and `JdbcEventPublicationAutoConfiguration` from `@Configuration(proxyBeanMethods = false)` to `@AutoConfiguration`, folding the standalone `@AutoConfigureBefore` on the JDBC one into the annotation's `before` attribute.

No runtime behavior change intended — all four classes were already registered via `AutoConfiguration.imports`.