### PR TITLE
GH-1783 - Invoke listeners through SimpleApplicationEventMulticaster

### DIFF
--- a/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/main/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticaster.java
@@ -35,8 +35,8 @@ import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.PayloadApplicationEvent;
-import org.springframework.context.event.AbstractApplicationEventMulticaster;
 import org.springframework.context.event.ApplicationListenerMethodAdapter;
+import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
@@ -69,7 +69,7 @@ import org.springframework.util.StringUtils;
  * @author Oliver Drotbohm
  * @see CompletionRegisteringAdvisor
  */
-public class PersistentApplicationEventMulticaster extends AbstractApplicationEventMulticaster
+public class PersistentApplicationEventMulticaster extends SimpleApplicationEventMulticaster
 		implements FailedEventPublications, IncompleteEventPublications, SmartInitializingSingleton {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(PersistentApplicationEventMulticaster.class);
@@ -141,7 +141,7 @@ public class PersistentApplicationEventMulticaster extends AbstractApplicationEv
 				.ifPresent(stream -> storePublications(stream, eventToPersist));
 
 		for (ApplicationListener listener : matchingListeners) {
-			listener.onApplicationEvent(event);
+			invokeListener(listener, event);
 		}
 	}
 

--- a/spring-modulith-events/spring-modulith-events-core/src/test/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticasterUnitTests.java
+++ b/spring-modulith-events/spring-modulith-events-core/src/test/java/org/springframework/modulith/events/support/PersistentApplicationEventMulticasterUnitTests.java
@@ -27,6 +27,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
 import org.springframework.context.PayloadApplicationEvent;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.event.ApplicationEventMulticaster;
@@ -180,6 +182,15 @@ class PersistentApplicationEventMulticasterUnitTests {
 		});
 	}
 
+	@Test // GH-1783
+	void doesNotPropagateClassCastExceptionOfNonMatchingLambdaListener() {
+
+		multicaster.addApplicationListener(ApplicationListener.forPayload(__ -> {}));
+
+		assertThatNoException()
+				.isThrownBy(() -> multicaster.multicastEvent(new SampleApplicationEvent(this)));
+	}
+
 	private static TransactionalApplicationListenerMethodAdapter getAdapter(Class<?> type, String methodName,
 			Class<?> parameter) {
 
@@ -215,6 +226,14 @@ class PersistentApplicationEventMulticasterUnitTests {
 
 		@ApplicationModuleListener
 		void on(SampleEvent event) {}
+	}
+
+	@SuppressWarnings("serial")
+	static class SampleApplicationEvent extends ApplicationEvent {
+
+		SampleApplicationEvent(Object source) {
+			super(source);
+		}
 	}
 
 	static class SampleEvent {


### PR DESCRIPTION
Fixes #1783

### Root cause

`PersistentApplicationEventMulticaster` invokes `ApplicationListener.onApplicationEvent(…)` directly, which bypasses the `ClassCastException` tolerance `SimpleApplicationEventMulticaster.doInvokeListener(…)` applies for lambda-defined listeners whose generic event type cannot be resolved by reflection. A listener created via `ApplicationListener.forPayload(…)` has no resolvable declared event type, so `getApplicationListeners(…)` reports it as a candidate for *every* event; publishing a non-payload event such as `ContextRefreshedEvent` then fails the lambda's implicit cast to `PayloadApplicationEvent`. Because the multicaster registers itself as the `applicationEventMulticaster` bean, merely adding event externalization to an application turns a listener that worked before into a context refresh failure.

### Change

`PersistentApplicationEventMulticaster` now extends `SimpleApplicationEventMulticaster` and delegates the listener invocation to `invokeListener(…)`. Both `multicastEvent(…)` overloads stay overridden, so the publication-registry logic is unchanged; the fix restores the invocation semantics of the multicaster that is being replaced and, as a side effect, honors a configured `ErrorHandler`.

### Tests

Added `PersistentApplicationEventMulticasterUnitTests.doesNotPropagateClassCastExceptionOfNonMatchingLambdaListener()`, which registers an `ApplicationListener.forPayload(…)` listener and multicasts a plain `ApplicationEvent`. It fails on `main` with exactly the reported exception and passes with the fix.

Verification done: reproduced the reported `ClassCastException` with a failing test on `upstream/main` (same stack frame as the issue, `PersistentApplicationEventMulticaster.multicastEvent`); `./mvnw test -pl :spring-modulith-events-core` — 49 tests, all green; `./mvnw test -pl :spring-modulith-events-tests -am` — events-core, events-jpa (59) and the integration example all green. Checked that `PersistentApplicationEventMulticaster` is not referenced as an `AbstractApplicationEventMulticaster` anywhere else in the codebase.
