### PR TITLE
GH-1778 - Clarify violation for non-exposed types in allowed modules

### DIFF
--- a/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModule.java
+++ b/spring-modulith-core/src/main/java/org/springframework/modulith/core/ApplicationModule.java
@@ -1345,6 +1345,21 @@ public class ApplicationModule implements Comparable<ApplicationModule> {
 			// Check explicitly defined allowed targets
 			if (!allowed.isAllowedDependency(target)) {
 
+				// When the target module is itself listed as an allowed dependency (for example via
+				// sharedModules) but the concrete type is not part of the allowed named interfaces,
+				// report a non-exposed-type violation. Otherwise the "Allowed targets: <module>"
+				// message is ambiguous (GH-1778).
+				var targetModuleAllowed = allowed.stream()
+						.anyMatch(it -> it.getTargetModule().equals(targetModule));
+
+				if (targetModuleAllowed && !targetModule.isExposed(target)) {
+
+					var violationText = INTERNAL_REFERENCE
+							.formatted(originModule.getIdentifier(), target.getName(), targetModule.getIdentifier());
+
+					return violations.and(new Violation(violationText + lineSeparator() + description));
+				}
+
 				var targetNamedInterfaces = targetModule.getNamedInterfaces()
 						.getNamedInterfacesContaining(target)
 						.filter(NamedInterface::isNamed)

--- a/spring-modulith-core/src/test/java/reproducers/gh1778/Application.java
+++ b/spring-modulith-core/src/test/java/reproducers/gh1778/Application.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reproducers.gh1778;
+
+import org.springframework.modulith.Modulithic;
+
+/**
+ * Reproducer application for GH-1778.
+ *
+ * @author Burak Kalayci
+ */
+@Modulithic(sharedModules = "review")
+public class Application {
+}

--- a/spring-modulith-core/src/test/java/reproducers/gh1778/Gh1778Tests.java
+++ b/spring-modulith-core/src/test/java/reproducers/gh1778/Gh1778Tests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reproducers.gh1778;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.modulith.core.ApplicationModules;
+import org.springframework.modulith.core.Violations;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+
+/**
+ * Regression tests for GH-1778.
+ *
+ * @author Burak Kalayci
+ */
+class Gh1778Tests {
+
+	@Test // GH-1778
+	void reportsNonExposedTypeWhenSharedModuleTargetIsNotExposed() {
+
+		var modules = ApplicationModules.of(Application.class, new ImportOption.OnlyIncludeTests());
+
+		assertThat(modules.getSharedModules())
+				.extracting(it -> it.getIdentifier().toString())
+				.containsExactly("review");
+
+		assertThatExceptionOfType(Violations.class) //
+				.isThrownBy(modules::verify) //
+				.satisfies(ex -> assertThat(ex.getMessages())
+						.anySatisfy(message -> assertThat(message)
+								.contains("Module 'bidding'")
+								.contains("non-exposed type")
+								.contains("reproducers.gh1778.review.analysis.AnalyzerService")
+								.contains("review")
+								.doesNotContain("Allowed targets")));
+	}
+}

--- a/spring-modulith-core/src/test/java/reproducers/gh1778/bidding/BidService.java
+++ b/spring-modulith-core/src/test/java/reproducers/gh1778/bidding/BidService.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reproducers.gh1778.bidding;
+
+import reproducers.gh1778.review.analysis.AnalyzerService;
+
+/**
+ * Depends on a non-exposed type of the shared review module.
+ *
+ * @author Burak Kalayci
+ */
+public class BidService {
+
+	private final AnalyzerService analyzerService;
+
+	public BidService(AnalyzerService analyzerService) {
+		this.analyzerService = analyzerService;
+	}
+}

--- a/spring-modulith-core/src/test/java/reproducers/gh1778/bidding/package-info.java
+++ b/spring-modulith-core/src/test/java/reproducers/gh1778/bidding/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(allowedDependencies = {})
+package reproducers.gh1778.bidding;

--- a/spring-modulith-core/src/test/java/reproducers/gh1778/review/analysis/AnalyzerService.java
+++ b/spring-modulith-core/src/test/java/reproducers/gh1778/review/analysis/AnalyzerService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package reproducers.gh1778.review.analysis;
+
+/**
+ * Internal type of the review module (not part of the exposed API package).
+ *
+ * @author Burak Kalayci
+ */
+public class AnalyzerService {
+}

--- a/spring-modulith-core/src/test/java/reproducers/gh1778/review/package-info.java
+++ b/spring-modulith-core/src/test/java/reproducers/gh1778/review/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(allowedDependencies = {})
+package reproducers.gh1778.review;


### PR DESCRIPTION
## Summary

Fixes #1778.

When a module is allowed as a dependency target (for example because it is listed in `@Modulithic(sharedModules = …)`) but the concrete type is not part of an allowed named interface, verification previously reported:

```text
Module 'bidding' depends on module 'review' via … Allowed targets: review.
```

That message is ambiguous: the module appears in the allowed targets list while the dependency is still rejected. The intended diagnosis is that the type is not exposed.

## Change

In `QualifiedDependency.isValidDependencyWithin`, if the target module is present in the origin module's allowed dependencies but the target type is not exposed, emit the existing non-exposed-type violation (`INTERNAL_REFERENCE`) instead of the generic "Allowed targets" message.

## Tests

- RED→GREEN reproducer `reproducers.gh1778.Gh1778Tests` (shared `review` module + internal `review.analysis.AnalyzerService`)
- `./mvnw -pl spring-modulith-core test` — 94/94 GREEN
- `./mvnw -pl spring-modulith-integration-test -am test -Dtest=ApplicationModulesIntegrationTest` — 19/19 GREEN