### PR TITLE
GH-1786 - Fix NPE in FormattableType.of()

### DIFF
--- a/spring-modulith-core/src/main/java/org/springframework/modulith/core/FormattableType.java
+++ b/spring-modulith-core/src/main/java/org/springframework/modulith/core/FormattableType.java
@@ -107,11 +107,16 @@ public class FormattableType {
 	 * @return will never be {@literal null}.
 	 */
 	public static FormattableType of(Class<?> type) {
+
+		Assert.notNull(type, "Type must not be null!");
+
 		return CACHE.computeIfAbsent(type.getTypeName(), FormattableType::new);
 	}
 
 	/**
-	 * Creates a new {@link FormattableType} for the given {@link ResolvableType}.
+	 * Creates a new {@link FormattableType} for the given {@link ResolvableType}. Unbounded wildcards and unresolvable
+	 * type variables ({@link ResolvableType#resolve()} returning {@literal null}) are represented as {@code ?}. Only the
+	 * resolved raw type is formatted so that callers can compose generic arguments recursively.
 	 *
 	 * @param type must not be {@literal null}.
 	 * @return will never be {@literal null}.
@@ -119,9 +124,12 @@ public class FormattableType {
 	 */
 	public static FormattableType of(ResolvableType type) {
 
-		var source = type.toString();
+		Assert.notNull(type, "ResolvableType must not be null!");
 
-		return source == "?" ? FormattableType.WILDCARD : CACHE.computeIfAbsent(source, FormattableType::new);
+		var resolved = type.resolve();
+
+		// Unbounded wildcards (Foo<?>) / type variables resolve to null
+		return resolved == null ? WILDCARD : of(resolved);
 	}
 
 	/**

--- a/spring-modulith-core/src/test/java/org/springframework/modulith/core/FormattableTypeUnitTests.java
+++ b/spring-modulith-core/src/test/java/org/springframework/modulith/core/FormattableTypeUnitTests.java
@@ -88,19 +88,38 @@ class FormattableTypeUnitTests {
 		assertThat(FormattableType.of(String[][].class).getFullName()).isEqualTo("java.lang.String[][]");
 	}
 
-	@Test // GH-1748
+	@Test // GH-1748, GH-1786
 	void handlesWildCardsAndUnresolvableGenerics() throws Exception {
 
 		var method = Sample.class.getMethod("wildcarded", List.class);
 
 		var parameterType = ResolvableType.forMethodParameter(method, 0);
 		var returnType = ResolvableType.forMethodReturnType(method);
+		var unboundedWildcard = returnType.getGeneric(0);
 
-		assertThat(FormattableType.of(parameterType).getAbbreviatedFullName()).isEqualTo("j.u.List<?>");
-		assertThat(FormattableType.of(returnType).getAbbreviatedFullName()).isEqualTo("j.u.List<?>");
+		// of(ResolvableType) formats the resolved raw type only; generics are composed by callers
+		assertThat(FormattableType.of(parameterType).getAbbreviatedFullName()).isEqualTo("j.u.List");
+		assertThat(FormattableType.of(returnType).getAbbreviatedFullName()).isEqualTo("j.u.List");
+
+		// Unbounded wildcard / unresolvable type variable → "?"
+		assertThat(FormattableType.of(unboundedWildcard).getAbbreviatedFullName()).isEqualTo("?");
+		assertThat(FormattableType.of(parameterType.getGeneric(0)).getAbbreviatedFullName()).isEqualTo("?");
+	}
+
+	@Test // GH-1786
+	void handlesClassWildcardWithoutException() throws Exception {
+
+		var method = Sample.class.getMethod("classWildcard", Class.class);
+		var parameterType = ResolvableType.forMethodParameter(method, 0);
+
+		assertThatNoException().isThrownBy(() -> FormattableType.of(parameterType));
+		assertThat(FormattableType.of(parameterType).getAbbreviatedFullName()).isEqualTo("j.l.Class");
+		assertThat(FormattableType.of(parameterType.getGeneric(0)).getAbbreviatedFullName()).isEqualTo("?");
 	}
 
 	interface Sample {
 		<T> List<?> wildcarded(List<T> parameterized);
+
+		void classWildcard(Class<?> type);
 	}
 }

--- a/spring-modulith-observability/spring-modulith-observability-core/src/test/java/example/sample/SampleComponent.java
+++ b/spring-modulith-observability/spring-modulith-observability-core/src/test/java/example/sample/SampleComponent.java
@@ -32,4 +32,6 @@ public class SampleComponent {
 	public void withWildcard(List<?> items) {}
 
 	public <T> void withTypeVariable(List<T> items) {}
+
+	public void withClassWildcard(Class<?> type) {}
 }

--- a/spring-modulith-observability/spring-modulith-observability-core/src/test/java/org/springframework/modulith/observability/support/DefaultObservedModuleUnitTests.java
+++ b/spring-modulith-observability/spring-modulith-observability-core/src/test/java/org/springframework/modulith/observability/support/DefaultObservedModuleUnitTests.java
@@ -53,22 +53,34 @@ class DefaultObservedModuleUnitTests {
 		assertThat(observedModule.isEventListenerInvocation(forMethod("someMethod"))).isFalse();
 	}
 
-	@Test // GH-1748
+	@Test // GH-1748, GH-1786
 	void rendersUnboundedWildcardGenericWithoutException() throws Exception {
 
 		var invocation = forMethod(new SampleComponent(), "withWildcard", List.class);
 
 		assertThatNoException().isThrownBy(() -> observedModule.format(invocation));
-		assertThat(observedModule.format(invocation)).contains("withWildcard(").contains("<?>");
+		assertThat(observedModule.format(invocation))
+				.isEqualTo("e.s.SampleComponent.withWildcard(j.u.List<?>)");
 	}
 
-	@Test // GH-1748
+	@Test // GH-1748, GH-1786
 	void rendersUnboundedTypeVariableGenericWithoutException() throws Exception {
 
 		var invocation = forMethod(new SampleComponent(), "withTypeVariable", List.class);
 
 		assertThatNoException().isThrownBy(() -> observedModule.format(invocation));
-		assertThat(observedModule.format(invocation)).contains("withTypeVariable(").contains("<?>");
+		assertThat(observedModule.format(invocation))
+				.isEqualTo("e.s.SampleComponent.withTypeVariable(j.u.List<?>)");
+	}
+
+	@Test // GH-1786
+	void rendersClassWildcardGenericWithoutException() throws Exception {
+
+		var invocation = forMethod(new SampleComponent(), "withClassWildcard", Class.class);
+
+		assertThatNoException().isThrownBy(() -> observedModule.format(invocation));
+		assertThat(observedModule.format(invocation))
+				.isEqualTo("e.s.SampleComponent.withClassWildcard(j.l.Class<?>)");
 	}
 
 	private static MethodInvocation forMethod(String name, Class<?>... parameterTypes) throws Exception {


### PR DESCRIPTION
## Summary

Fixes #1786.

When observability renders an observed method whose parameter type involves an **unbounded wildcard** (for example `Class<?>` as used by `AbstractHttpMessageConverter.canWrite/canRead`, or `List<?>` / `List<T>`), `ResolvableType.resolve()` returns `null`. Feeding that into `FormattableType.of(Class)` NPE'd on `type.getTypeName()`.

This is the same root cause as #1748 / #1713. Main already routes through `FormattableType.of(ResolvableType)`, but that factory used `type.toString()` as a type name. That:

1. Does not correctly treat a bare `?` / unresolvable type variable as the wildcard token for all call paths.
2. Embeds generic arguments in the string, so `DefaultObservedModule.render` then **double-appended** them (`List<?><?>`) and mangled nested generics during package abbreviation (`Map<String, List<?>>` → `j.u.M.l.S.u.List<?>>`).

## Fix

`FormattableType.of(ResolvableType)` now:

- Asserts the argument is non-null
- Uses `resolve()` and maps `null` to the existing `?` wildcard instance
- Formats only the resolved **raw** type so callers (e.g. `DefaultObservedModule.render`) can still compose generic arguments recursively

Also adds `Assert.notNull` on `of(Class)` for consistency with `of(JavaClass)`.

## Tests

- `FormattableTypeUnitTests` — unbounded wildcard / type variable → `?`; `Class<?>` regression (GH-1786)
- `DefaultObservedModuleUnitTests` — exact signatures for `List<?>`, `List<T>`, and `Class<?>`

```
./mvnw -pl spring-modulith-core,spring-modulith-observability/spring-modulith-observability-core -am \
  test -Dtest=FormattableTypeUnitTests,DefaultObservedModuleUnitTests \
  -Dsurefire.failIfNoSpecifiedTests=false
```

- `FormattableTypeUnitTests`: 9/9
- `DefaultObservedModuleUnitTests`: 4/4  
- Temurin 21

## Documentation

- [x] Not needed (bug fix only)