### PR TITLE
GH-1789 - Use ConcurrentHashMap for the module dependency cache.

### DIFF
--- a/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/TestExecutionCondition.java
+++ b/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/TestExecutionCondition.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.modulith.junit;
 
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -45,7 +45,7 @@ class TestExecutionCondition {
 	private static final Logger log = LoggerFactory.getLogger(TestExecutionCondition.class);
 	private static final AnnotatedClassFinder SPA_CLASS_FINDER = new AnnotatedClassFinder(SpringBootConfiguration.class);
 
-	private final Map<ApplicationModule, ApplicationModuleDependencies> dependencies = new HashMap<>();
+	private final Map<ApplicationModule, ApplicationModuleDependencies> dependencies = new ConcurrentHashMap<>();
 
 	ConditionEvaluationResult evaluate(ConditionContext context) {
 

--- a/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/TestExecutionCondition.java
+++ b/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/TestExecutionCondition.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.modulith.junit;
 
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.jspecify.annotations.Nullable;


### PR DESCRIPTION
Fixes #1789

`TestExecutionCondition.evaluate(…)` is called concurrently when `junit.jupiter.execution.parallel.mode.classes.default=concurrent` is configured, so `computeIfAbsent` on the plain `HashMap` can fail with a `ConcurrentModificationException`. Switching to `ConcurrentHashMap` keeps the caching behaviour and makes the field safe for concurrent access; `ApplicationModule.getAllDependencies(…)` never returns `null`, so the map's null-hostility is not a concern.

Observed on 2.0.6 with 74 of 602 test classes failing per run (different classes each time). No regression test added: reproducing the race deterministically isn't practical. Happy to add a stress test if you'd prefer one.

Signed-off-by: Arend van Erk <arend.vanerk@omoda.nl>