### PR TITLE
GH-924 - Allow configuring the database type for JDBC event publications

### DIFF
--- a/spring-modulith-events/spring-modulith-events-jdbc/src/main/java/org/springframework/modulith/events/jdbc/JdbcConfigurationProperties.java
+++ b/spring-modulith-events/spring-modulith-events-jdbc/src/main/java/org/springframework/modulith/events/jdbc/JdbcConfigurationProperties.java
@@ -32,20 +32,24 @@ class JdbcConfigurationProperties {
 	private final SchemaInitialization schemaInitialization;
 	private final @Nullable String schema;
 	private final boolean useLegacyStructure;
+	private final @Nullable DatabaseType databaseType;
 
 	/**
 	 * Creates a new {@link JdbcConfigurationProperties} instance.
 	 *
 	 * @param schemaInitialization whether to initialize the JDBC event publication schema. Defaults to {@literal false}.
 	 * @param schema the schema name of event publication table, can be {@literal null}.
+	 * @param databaseType the database type to use, can be {@literal null}. If not set, the type is detected from the
+	 *          {@link javax.sql.DataSource}.
 	 */
 	@ConstructorBinding
 	JdbcConfigurationProperties(SchemaInitialization schemaInitialization, @Nullable String schema,
-			@Nullable Boolean useLegacyStructure) {
+			@Nullable Boolean useLegacyStructure, @Nullable DatabaseType databaseType) {
 
 		this.schemaInitialization = schemaInitialization;
 		this.schema = schema;
 		this.useLegacyStructure = useLegacyStructure == null ? false : useLegacyStructure.booleanValue();
+		this.databaseType = databaseType;
 	}
 
 	/**
@@ -71,6 +75,16 @@ class JdbcConfigurationProperties {
 	 */
 	public boolean isUseLegacyStructure() {
 		return useLegacyStructure;
+	}
+
+	/**
+	 * The database type to use. If not set, the type is detected from the {@link javax.sql.DataSource}.
+	 *
+	 * @return can be {@literal null}.
+	 * @since 2.2
+	 */
+	public @Nullable DatabaseType getDatabaseType() {
+		return databaseType;
 	}
 
 	void verify(DatabaseType databaseType) {

--- a/spring-modulith-events/spring-modulith-events-jdbc/src/main/java/org/springframework/modulith/events/jdbc/JdbcEventPublicationAutoConfiguration.java
+++ b/spring-modulith-events/spring-modulith-events-jdbc/src/main/java/org/springframework/modulith/events/jdbc/JdbcEventPublicationAutoConfiguration.java
@@ -49,8 +49,11 @@ class JdbcEventPublicationAutoConfiguration implements EventPublicationConfigura
 	@Autowired Environment environment;
 
 	@Bean
-	DatabaseType databaseType(DataSource dataSource) {
-		return DatabaseType.from(fromDataSource(dataSource));
+	DatabaseType databaseType(DataSource dataSource, JdbcConfigurationProperties properties) {
+
+		var configured = properties.getDatabaseType();
+
+		return configured != null ? configured : DatabaseType.from(fromDataSource(dataSource));
 	}
 
 	@Bean

--- a/spring-modulith-events/spring-modulith-events-jdbc/src/test/java/org/springframework/modulith/events/jdbc/DatabaseSchemaInitializerUnitTests.java
+++ b/spring-modulith-events/spring-modulith-events-jdbc/src/test/java/org/springframework/modulith/events/jdbc/DatabaseSchemaInitializerUnitTests.java
@@ -74,6 +74,6 @@ class DatabaseSchemaInitializerUnitTests {
 	}
 
 	private static JdbcConfigurationProperties withSchema(String schema) {
-		return new JdbcConfigurationProperties(new SchemaInitialization(true), schema, false);
+		return new JdbcConfigurationProperties(new SchemaInitialization(true), schema, false, null);
 	}
 }

--- a/spring-modulith-events/spring-modulith-events-jdbc/src/test/java/org/springframework/modulith/events/jdbc/JdbcEventPublicationAutoConfigurationUnitTests.java
+++ b/spring-modulith-events/spring-modulith-events-jdbc/src/test/java/org/springframework/modulith/events/jdbc/JdbcEventPublicationAutoConfigurationUnitTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.events.jdbc;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.modulith.events.jdbc.JdbcConfigurationProperties.SchemaInitialization;
+
+/**
+ * Unit tests for {@link JdbcEventPublicationAutoConfiguration}.
+ *
+ * @author Kirill Adzerikho
+ */
+class JdbcEventPublicationAutoConfigurationUnitTests {
+
+	@Test // GH-924
+	void usesConfiguredDatabaseTypeWithoutTouchingTheDataSource() {
+
+		var properties = new JdbcConfigurationProperties(new SchemaInitialization(false), null, null,
+				DatabaseType.POSTGRES);
+		var configuration = new JdbcEventPublicationAutoConfiguration();
+
+		var dataSource = mock(DataSource.class, invocation -> {
+			throw new AssertionError("DataSource must not be touched!");
+		});
+
+		assertThat(configuration.databaseType(dataSource, properties)).isEqualTo(DatabaseType.POSTGRES);
+	}
+
+	@Test // GH-924
+	void detectsDatabaseTypeFromDataSourceWithoutConfiguredType() throws Exception {
+
+		var properties = new JdbcConfigurationProperties(new SchemaInitialization(false), null, null, null);
+		var configuration = new JdbcEventPublicationAutoConfiguration();
+
+		var dataSource = mock(DataSource.class, RETURNS_DEEP_STUBS);
+		when(dataSource.getConnection().getMetaData().getDatabaseProductName()).thenReturn("PostgreSQL");
+
+		assertThat(configuration.databaseType(dataSource, properties)).isEqualTo(DatabaseType.POSTGRES);
+	}
+}

--- a/src/docs/antora/modules/ROOT/pages/appendix.adoc
+++ b/src/docs/antora/modules/ROOT/pages/appendix.adoc
@@ -91,6 +91,13 @@ The following values are supported:
 |`false`
 |Whether to serialize event externalization to brokers.
 
+|`spring.modulith.events.jdbc.database-type`
+|
+|The database type to use for the event publication table.
+If not set, the type is detected by opening a connection to the `DataSource`.
+Configuring it explicitly keeps the application context bootstrappable without database access, such as in CDS or AOT cache training runs.
+The following values are supported: `h2`, `hsqldb`, `mariadb`, `mssql`, `mysql`, `oracle`, `postgres`.
+
 |`spring.modulith.events.jdbc.schema-initialization.enabled`
 |`true`
 |Whether to initialize the JDBC event publication schema.


### PR DESCRIPTION
Closes #924.

`JdbcEventPublicationAutoConfiguration.databaseType(…)` unconditionally opens a database connection to detect the `DatabaseType`. That breaks application contexts that have to bootstrap without database access — most prominently CDS / JDK AOT cache training runs (`-Dspring.context.exit=onRefresh`), where Flyway and Liquibase already offer an opt-out.

This change introduces `spring.modulith.events.jdbc.database-type`. If set, the auto-configuration uses the configured type as is and never touches the `DataSource`; if not set, the previous detection via connection metadata applies unchanged.

Verified with the new unit tests (`JdbcEventPublicationAutoConfigurationUnitTests`) and the existing module test suite.
