### PR TITLE
GH-1849 Fix `WorkingDirectoryChangesDetector` for git submodule work trees

### DIFF
--- a/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/diff/WorkingDirectoryChangesDetector.java
+++ b/spring-modulith-junit/src/main/java/org/springframework/modulith/junit/diff/WorkingDirectoryChangesDetector.java
@@ -56,13 +56,34 @@ class WorkingDirectoryChangesDetector implements FileModificationDetector {
 	 */
 	public static WorkingDirectoryChangesDetector of(FileModificationDetector delegate) {
 
-		var pathToRepo = JGitUtil.withRepository(it -> it.getDirectory().getParent());
-		var currentWorkingDirectory = new File("").getAbsolutePath();
-		var repositoryRelative = !pathToRepo.equals(currentWorkingDirectory)
-				? currentWorkingDirectory.substring(pathToRepo.length() + 1)
-				: "";
+		var pathToRepo = JGitUtil.withRepository(it -> it.getWorkTree().getAbsolutePath());
+		var repositoryRelative = repositoryRelativeWorkingDirectory(pathToRepo, new File("").getAbsolutePath());
 
 		return new WorkingDirectoryChangesDetector(delegate, repositoryRelative);
+	}
+
+	/**
+	 * Returns the path of {@code absoluteWorkingDirectory} relative to the Git work tree root.
+	 * <p>
+	 * When tests run from a nested build module, the JVM working directory sits below the
+	 * repository root. This value is used to scope change detection to files under that
+	 * directory. Returns an empty string when the working directory is the repository root.
+	 * <p>
+	 * Package-private to allow direct unit testing of the path computation.
+	 *
+	 * @param repositoryRoot absolute path to the Git work tree root, must not be {@literal null}.
+	 * @param absoluteWorkingDirectory absolute path of the current working directory, must not be
+	 *          {@literal null}.
+	 * @return repository-relative working directory path, or {@literal ""} if already at the root.
+	 */
+	static String repositoryRelativeWorkingDirectory(String repositoryRoot, String absoluteWorkingDirectory) {
+
+		Assert.notNull(repositoryRoot, "Repository root must not be null!");
+		Assert.notNull(absoluteWorkingDirectory, "Working directory must not be null!");
+
+		return !repositoryRoot.equals(absoluteWorkingDirectory)
+				? absoluteWorkingDirectory.substring(repositoryRoot.length() + 1)
+				: "";
 	}
 
 	/*

--- a/spring-modulith-junit/src/test/java/org/springframework/modulith/junit/diff/WorkingDirectoryChangesDetectorUnitTests.java
+++ b/spring-modulith-junit/src/test/java/org/springframework/modulith/junit/diff/WorkingDirectoryChangesDetectorUnitTests.java
@@ -18,10 +18,16 @@ package org.springframework.modulith.junit.diff;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.stream.Stream;
 
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -47,5 +53,95 @@ class WorkingDirectoryChangesDetectorUnitTests {
 		assertThat(detector.getModifiedFiles())
 				.extracting(ModifiedFile::path)
 				.containsExactly("nestedPom.xml");
+	}
+
+	@Test
+	void resolvesRepositoryRelativeWorkingDirectoryForNestedMavenModule() {
+
+		var repositoryRoot = "/tmp/example-repository";
+		var nestedModule = repositoryRoot + "/nested-module";
+
+		assertThat(WorkingDirectoryChangesDetector.repositoryRelativeWorkingDirectory(repositoryRoot, nestedModule))
+				.isEqualTo("nested-module");
+	}
+
+	@Test // GH-1849
+	void resolvesRepositoryRelativeWorkingDirectoryForGitSubmoduleWorkTree() {
+
+		var workTree = "/tmp/parent-repository/example-library";
+		var gitMetadataDirectory = "/tmp/parent-repository/.git/modules/example-library";
+		var nestedModule = workTree + "/example-library-core";
+
+		assertThat(nestedModule).doesNotStartWith(gitMetadataDirectory);
+
+		assertThat(WorkingDirectoryChangesDetector.repositoryRelativeWorkingDirectory(workTree, nestedModule))
+				.isEqualTo("example-library-core");
+	}
+
+	@Test // GH-1849
+	void filtersModifiedFilesForGitSubmoduleWorkTree(@TempDir Path temp) throws Exception {
+
+		var nestedModule = initSubmoduleStyleRepository(temp);
+
+		when(delegate.getModifiedFiles())
+				.thenReturn(Stream.of("README", "module-a/pom.xml", "module-b/pom.xml").map(ModifiedFile::new));
+
+		var repositoryRelative = WorkingDirectoryChangesDetector.repositoryRelativeWorkingDirectory(
+				nestedModule.getParent().toAbsolutePath().toString(), nestedModule.toAbsolutePath().toString());
+
+		var detector = new WorkingDirectoryChangesDetector(delegate, repositoryRelative);
+
+		assertThat(detector.getModifiedFiles())
+				.extracting(ModifiedFile::path)
+				.containsExactly("pom.xml");
+	}
+
+	@Test // GH-1849
+	void usesWorkTreeWhenResolvingRepositoryRoot(@TempDir Path temp) throws Exception {
+
+		var nestedModule = initSubmoduleStyleRepository(temp);
+		var workTree = nestedModule.getParent();
+		var gitDir = workTree.getParent().resolve("parent-repository/.git/modules/example-library");
+
+		try (Repository repository = new FileRepositoryBuilder()
+				.setGitDir(gitDir.toFile())
+				.setWorkTree(workTree.toFile())
+				.build()) {
+
+			assertThat(repository.getWorkTree().getAbsolutePath()).isEqualTo(workTree.toAbsolutePath().toString());
+			assertThat(repository.getDirectory().getParent()).isNotEqualTo(repository.getWorkTree().getAbsolutePath());
+		}
+	}
+
+	private static Path initSubmoduleStyleRepository(Path temp) throws Exception {
+
+		var parentRepository = temp.resolve("parent-repository");
+		var gitDir = parentRepository.resolve(".git/modules/example-library");
+		var workTree = temp.resolve("example-library");
+		var nestedModule = workTree.resolve("module-a");
+
+		Files.createDirectories(gitDir);
+		Files.createDirectories(nestedModule);
+		Files.createDirectories(workTree.resolve("module-b"));
+
+		Git.init().setDirectory(gitDir.toFile()).setBare(true).call();
+
+		Files.writeString(workTree.resolve("README"), "example");
+		Files.writeString(workTree.resolve("module-a/pom.xml"), "module-a");
+		Files.writeString(workTree.resolve("module-b/pom.xml"), "module-b");
+		Files.writeString(workTree.resolve(".git"), "gitdir: " + gitDir.toAbsolutePath() + "\n");
+
+		Repository repository = new FileRepositoryBuilder()
+				.setGitDir(gitDir.toFile())
+				.setWorkTree(workTree.toFile())
+				.build();
+
+		try (Git git = new Git(repository)) {
+
+			git.add().addFilepattern(".").call();
+			git.commit().setMessage("init").call();
+		}
+
+		return nestedModule;
 	}
 }


### PR DESCRIPTION
Closes #1849

## Summary

`WorkingDirectoryChangesDetector.of()` resolves the repository root via `repository.getDirectory().getParent()`. In a git submodule checkout, `.git` is a `gitdir:` pointer into the parent repository's `.git/modules/...` directory, so that path points at git metadata rather than the submodule work tree.

When JUnit tests run from a nested Maven module inside such a work tree, computing the repository-relative working directory can throw `StringIndexOutOfBoundsException` during `ModulithExecutionCondition` evaluation — before any application tests execute.

## Fix

Use `repository.getWorkTree().getAbsolutePath()` as the repository root, which is correct for standard repositories and submodule work trees alike.

Path computation is extracted into `repositoryRelativeWorkingDirectory(...)` so it can be unit-tested directly (without relying on JVM working-directory changes under Surefire).

## Tests

- Repository-relative path resolution for nested Maven modules
- Git submodule-style work tree with external git directory
- Filtering modified files to the current nested module
- Assertion that git directory parent and work tree differ for submodule layouts