### PR TITLE
GH-1763 - Register JDBC event publication auto-configuration for JDBC slice tests.

### DIFF
--- a/spring-modulith-events/spring-modulith-events-jdbc/pom.xml
+++ b/spring-modulith-events/spring-modulith-events-jdbc/pom.xml
@@ -65,6 +65,19 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-data-jdbc-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>spring-modulith-events-jackson</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
 			<scope>test</scope>

--- a/spring-modulith-events/spring-modulith-events-jdbc/src/main/resources/META-INF/spring/org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureJdbc.imports
+++ b/spring-modulith-events/spring-modulith-events-jdbc/src/main/resources/META-INF/spring/org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureJdbc.imports
@@ -1,0 +1,3 @@
+org.springframework.modulith.events.jdbc.JdbcEventPublicationAutoConfiguration
+optional:org.springframework.modulith.events.jackson.JacksonEventSerializationConfiguration
+optional:org.springframework.modulith.events.jackson2.Jackson2EventSerializationConfiguration

--- a/spring-modulith-events/spring-modulith-events-jdbc/src/test/java/org/springframework/modulith/events/jdbc/JdbcEventPublicationSliceAutoConfigurationIntegrationTests.java
+++ b/spring-modulith-events/spring-modulith-events-jdbc/src/test/java/org/springframework/modulith/events/jdbc/JdbcEventPublicationSliceAutoConfigurationIntegrationTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.modulith.events.jdbc;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest;
+import org.springframework.boot.jdbc.test.autoconfigure.JdbcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.modulith.events.core.EventPublicationRepository;
+import org.springframework.modulith.events.core.EventSerializer;
+
+/**
+ * Integration tests for the registration of {@link JdbcEventPublicationAutoConfiguration} for JDBC-based slice tests.
+ *
+ * @author Hyun Lee
+ */
+class JdbcEventPublicationSliceAutoConfigurationIntegrationTests {
+
+	@TestFactory // GH-1763
+	Stream<DynamicTest> registersEventPublicationRepositoryForSlices() {
+
+		return DynamicTest.stream(Stream.of(JdbcSlicing.class, DataJdbcSlicing.class),
+				it -> getTestAnnotationName(it) + " registers the event publication repository",
+				it -> new ApplicationContextRunner()
+						.withUserConfiguration(it)
+						.run(context -> {
+							assertThat(context).hasNotFailed();
+							assertThat(context).hasSingleBean(EventPublicationRepository.class);
+							assertThat(context).hasSingleBean(EventSerializer.class);
+						}));
+	}
+
+	private static String getTestAnnotationName(Class<?> type) {
+
+		return Stream.of(type.getDeclaredAnnotations())
+				.map(Annotation::annotationType)
+				.map(Class::getSimpleName)
+				.filter(it -> it.endsWith("Test"))
+				.findFirst()
+				.orElseThrow();
+	}
+
+	@TestConfiguration
+	@JdbcTest
+	static class JdbcSlicing {}
+
+	@TestConfiguration
+	@DataJdbcTest
+	@AutoConfigurationPackage
+	static class DataJdbcSlicing {}
+}


### PR DESCRIPTION
Closes #1763.

Reworked following the suggestion in #1763: instead of making `JdbcEventPublicationAutoConfiguration` public, the JDBC-specific auto-configuration is now included in the corresponding slice tests out of the box, along the lines of GH-1706. The earlier visibility change is dropped.

- Adds `META-INF/spring/org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureJdbc.imports` to `spring-modulith-events-jdbc`. `@AutoConfigureDataJdbc` is meta-annotated with `@AutoConfigureJdbc`, so the single file covers both `@JdbcTest` and `@DataJdbcTest`.
- Lists the Jackson `EventSerializer` configurations as `optional:` entries in the same file. The repository cannot be created without a serializer and the JSON auto-configuration is not part of the JDBC slices, so registering the JDBC configuration alone would make `@JdbcTest` fail to start for anyone with `spring-modulith-events-jdbc` on the classpath and no serializer in the slice. Both serializer configurations are `@ConditionalOnMissingBean(EventSerializer.class)`, so a serializer declared or mocked in a test still takes precedence. If you would rather have that registration live in `spring-modulith-events-jackson`, I'm happy to move it.
- `JdbcEventPublicationSliceAutoConfigurationIntegrationTests` bootstraps `@JdbcTest` and `@DataJdbcTest` configurations through an `ApplicationContextRunner`, as the GH-1706 test does, and expects a single `EventPublicationRepository` and `EventSerializer`. Both cases fail without the imports file, and fail with `No qualifying bean of type 'EventSerializer'` without the Jackson entries. The `@DataJdbcTest` fixture carries `@AutoConfigurationPackage`, as Spring Data JDBC's repository scanning needs a base package when no `@SpringBootApplication` is present.
- Adds `spring-boot-data-jdbc-test` and `spring-modulith-events-jackson` as test dependencies of the JDBC module.
