### PR TITLE
GH-1864 - Include initializers in AOT-generated application module metadata.

### DIFF
--- a/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/autoconfigure/ApplicationModulesFileGeneratingProcessor.java
+++ b/spring-modulith-runtime/src/main/java/org/springframework/modulith/runtime/autoconfigure/ApplicationModulesFileGeneratingProcessor.java
@@ -60,7 +60,7 @@ class ApplicationModulesFileGeneratingProcessor implements BeanFactoryInitializa
 
 			context.getGeneratedFiles().handleFile(Kind.RESOURCE, location, it -> {
 
-				var resource = new ByteArrayResource(exporter.toJson().getBytes(StandardCharsets.UTF_8));
+				var resource = new ByteArrayResource(exporter.toFullJson().getBytes(StandardCharsets.UTF_8));
 
 				if (it.exists()) {
 					it.override(resource);

--- a/spring-modulith-runtime/src/test/java/example/moduleA/ModuleAType.java
+++ b/spring-modulith-runtime/src/test/java/example/moduleA/ModuleAType.java
@@ -18,10 +18,12 @@ package example.moduleA;
 import java.time.LocalDateTime;
 
 import org.springframework.modulith.ApplicationModuleInitializer;
+import org.springframework.stereotype.Component;
 
 /**
  * @author Oliver Drotbohm
  */
+@Component
 public class ModuleAType implements ApplicationModuleInitializer {
 
 	public LocalDateTime initialized;

--- a/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/autoconfigure/ApplicationModulesFileGeneratingProcessorTests.java
+++ b/spring-modulith-runtime/src/test/java/org/springframework/modulith/runtime/autoconfigure/ApplicationModulesFileGeneratingProcessorTests.java
@@ -18,14 +18,21 @@ package org.springframework.modulith.runtime.autoconfigure;
 import static org.assertj.core.api.Assertions.*;
 
 import example.SampleApplication;
+import example.moduleA.ModuleAType;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.aot.generate.GeneratedFiles.Kind;
 import org.springframework.aot.test.generate.TestGenerationContext;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.aot.ApplicationContextAotGenerator;
 import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.modulith.core.util.ApplicationModulesExporter;
 import org.springframework.modulith.runtime.ApplicationModulesRuntime;
 import org.springframework.modulith.runtime.ApplicationRuntime;
 import org.springframework.modulith.test.TestApplicationModules;
@@ -49,6 +56,19 @@ class ApplicationModulesFileGeneratingProcessorTests {
 		assertThatNoException().isThrownBy(() -> {
 			generator.processAheadOfTime(createContext(), generationContext);
 		});
+	}
+
+	@Test // GH-1864
+	void generatedMetadataListsInitializers() throws IOException {
+
+		var generationContext = new TestGenerationContext();
+		new ApplicationContextAotGenerator().processAheadOfTime(createContext(), generationContext);
+
+		var json = generationContext.getGeneratedFiles()
+				.getGeneratedFileContent(Kind.RESOURCE, ApplicationModulesExporter.DEFAULT_LOCATION);
+		var metadata = ApplicationModuleMetadata.of(new ByteArrayResource(json.getBytes(StandardCharsets.UTF_8)));
+
+		assertThat(metadata.getInitializerTypeNames()).containsExactly(ModuleAType.class.getName());
 	}
 
 	private static GenericApplicationContext createContext() {


### PR DESCRIPTION
Closes #1864.

`ApplicationModulesFileGeneratingProcessor` wrote `ApplicationModulesExporter.toJson()`, the actuator subset without `initializers`. At runtime that file still counts as present, so `PrecomputedApplicationModuleInitializerInvoker` got an empty list and invoked initializers in `HashMap` order instead of dependency order.

Switches the processor to `toFullJson()`, which is what `Documenter.writeModuleMetadata()` writes already.

Adds `generatedMetadataListsInitializers` to `ApplicationModulesFileGeneratingProcessorTests`: runs AOT processing, reads the generated resource back through `ApplicationModuleMetadata`, and expects the initializer type name. `example.moduleA.ModuleAType` is now annotated with `@Component` so the exporter lists it. The test fails on `main` with `Expecting actual: []` and passes with the change; the rest of the `spring-modulith-runtime` suite is unaffected.
